### PR TITLE
Rework the landing example: plain method hero plus a stream-vs-DCB comparison

### DIFF
--- a/_includes/kotlinSnippet.html
+++ b/_includes/kotlinSnippet.html
@@ -1,0 +1,3 @@
+<div class="single-snippet" markdown="1">
+~~~kotlin{{include.kotlin}}~~~
+</div>

--- a/_includes/landing.css
+++ b/_includes/landing.css
@@ -250,3 +250,44 @@ nav ul li a:hover {
     }
 
 }
+
+.comparecaption {
+    max-width: 760px;
+    margin: 0 auto 28px;
+    color: #444;
+}
+
+.compare {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    max-width: 1000px;
+    margin: 0 auto;
+    text-align: left;
+}
+
+.compare-col {
+    flex: 1 1 calc(50% - 12px);
+    min-width: 280px;
+}
+
+.compare-col h3 {
+    margin: 0 0 8px;
+    font-weight: 500;
+    text-transform: none;
+}
+
+.compare .single-snippet pre {
+    margin: 0;
+    border-radius: 5px;
+}
+
+.compare .single-snippet pre code {
+    font-size: 13px;
+}
+
+@media (max-width: 700px) {
+    .compare-col {
+        flex-basis: 100%;
+    }
+}

--- a/_includes/landing.css
+++ b/_includes/landing.css
@@ -269,6 +269,8 @@ nav ul li a:hover {
 .compare-col {
     flex: 1 1 calc(50% - 12px);
     min-width: 280px;
+    display: flex;
+    flex-direction: column;
 }
 
 .compare-col h3 {
@@ -277,9 +279,29 @@ nav ul li a:hover {
     text-transform: none;
 }
 
+/* Stretch the code block to fill the column so both backgrounds line up even when
+   one example has more lines than the other. */
+.compare-col .single-snippet {
+    flex: 1;
+    display: flex;
+}
+
+.compare-col .single-snippet .highlighter-rouge {
+    flex: 1;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.compare-col .single-snippet .highlight {
+    flex: 1;
+}
+
 .compare .single-snippet pre {
     margin: 0;
     border-radius: 5px;
+    height: 100%;
+    box-sizing: border-box;
 }
 
 .compare .single-snippet pre code {

--- a/_includes/macros/gettingStarted.md
+++ b/_includes/macros/gettingStarted.md
@@ -1,24 +1,18 @@
 {% capture java %}
-// Your domain stays pure, with no dependency on Occurrent. A Decider is two functions:
-// decide(command, state) returns the new events, and evolve(state, event) folds an event into the state.
-Decider<GameCommand, GameState, GameEvent> game = Decider.create(initialState, this::decide, this::evolve);
+// Your domain is a pure function from past events to new events, with no dependency on Occurrent.
+List<GameEvent> handle(List<GameEvent> history, GameCommand command) { ... }
 
-// Occurrent supplies the plumbing. Its application service loads the stream, runs your decider,
-// and appends the new events under optimistic concurrency.
+// Occurrent's application service loads the stream, runs your function, and appends the new events under optimistic concurrency.
 ApplicationService<GameEvent> applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
-applicationService.execute(gameId, events -> game.decideOnEventsAndReturnEvents(events, command));
+applicationService.execute(gameId, history -> handle(history, command));
 {% endcapture %}
 
 {% capture kotlin %}
-import org.occurrent.dsl.decider.execute
+// Your domain is a pure function from past events to new events, with no dependency on Occurrent.
+fun handle(history: List<GameEvent>, command: GameCommand): List<GameEvent> { ... }
 
-// Your domain stays pure, with no dependency on Occurrent. A Decider is two functions:
-// decide(command, state) returns the new events, and evolve(state, event) folds an event into the state.
-val game = Decider.create(initialState, ::decide, ::evolve)
-
-// Occurrent supplies the plumbing. Its application service loads the stream, runs your decider,
-// and appends the new events under optimistic concurrency.
+// Occurrent's application service loads the stream, runs your function, and appends the new events under optimistic concurrency.
 val applicationService = GenericApplicationService(eventStore, cloudEventConverter)
-applicationService.execute(gameId, command, game)
+applicationService.execute(gameId) { history -> handle(history, command) }
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}

--- a/_includes/macros/gettingStarted.md
+++ b/_includes/macros/gettingStarted.md
@@ -1,46 +1,24 @@
 {% capture java %}
-public class ApplicationService {
+// Your domain stays pure, with no dependency on Occurrent. A Decider is two functions:
+// decide(command, state) returns the new events, and evolve(state, event) folds an event into the state.
+Decider<GameCommand, GameState, GameEvent> game = Decider.create(initialState, this::decide, this::evolve);
 
-    private final EventStore eventStore;
-    private final Converter converter;
-
-    public ApplicationService(EventStore eventStore, Converter converter) {
-        this.eventStore = eventStore;
-        this.converter = converter;
-    }
-
-    public void execute(String streamId, Function<List<DomainEvent>, List<DomainEvent>> functionThatCallsDomainModel) {
-        // Read all events from the event store for a particular stream
-        EventStream<CloudEvent> eventStream = eventStore.read(streamId.toString());
-        // Convert the cloud events into domain events
-        List<DomainEvent> persistedDomainEvents = eventStream.events().map(converter::toDomainEvent).toList();
-
-        // Call a pure function from the domain model which returns a List of domain events
-        List<DomainEvent> newDomainEvents = functionThatCallsDomainModel.apply(persistedDomainEvents);
-
-        // Convert domain events to cloud events and write them to the event store
-        List<CloudEvent> newCloudEvents = newDomainEvents.stream().map(converter::toCloudEvent).toList();
-        eventStore.write(streamId, eventStream.version(), newCloudEvents);
-    }
-}
+// Occurrent supplies the plumbing. Its application service loads the stream, runs your decider,
+// and appends the new events under optimistic concurrency.
+ApplicationService<GameEvent> applicationService = new GenericApplicationService<>(eventStore, cloudEventConverter);
+applicationService.execute(gameId, events -> game.decideOnEventsAndReturnEvents(events, command));
 {% endcapture %}
 
 {% capture kotlin %}
-class ApplicationService constructor (val eventStore : EventStore, val converter : Converter) {
+import org.occurrent.dsl.decider.execute
 
-    fun execute(streamId : String, functionThatCallsDomainModel : (List<DomainEvent>) -> List<DomainEvent>) {
-        // Read all events from the event store for a particular stream
-        val  eventStream : EventStream<CloudEvent> = eventStore.read(streamId.toString())
-        // Convert the cloud events into domain events
-        val persistedDomainEvents : List<DomainEvent> = eventStream.events().map(converter::toDomainEvent).toList()
+// Your domain stays pure, with no dependency on Occurrent. A Decider is two functions:
+// decide(command, state) returns the new events, and evolve(state, event) folds an event into the state.
+val game = Decider.create(initialState, ::decide, ::evolve)
 
-        // Call a pure function from the domain model which returns a List of domain events
-        val newDomainEvents = functionThatCallsDomainModel(persistedDomainEvents)
-
-        // Convert domain events to cloud events and write them to the event store
-        val newCloudEvents = newDomainEvents.map(converter::toCloudEvent)
-        eventStore.write(streamId, eventStream.version(), newCloudEvents)
-    }
-}
+// Occurrent supplies the plumbing. Its application service loads the stream, runs your decider,
+// and appends the new events under optimistic concurrency.
+val applicationService = GenericApplicationService(eventStore, cloudEventConverter)
+applicationService.execute(gameId, command, game)
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}

--- a/pages/index.md
+++ b/pages/index.md
@@ -17,6 +17,37 @@ permalink: /
     </div>
 </div>
 
+{% capture streamDecider %}
+// One boundary per stream
+val game = Decider.create(
+    initialState, ::decide, ::evolve
+)
+applicationService.execute(gameId, command, game)
+{% endcapture %}
+{% capture dcbDecider %}
+// A boundary per decision, across entities
+val game = DcbDecider.create(
+    initialState, ::decide, ::evolve,
+    ::boundaryFor, ::tagsFor
+)
+dcbApplicationService.execute(command, game)
+{% endcapture %}
+
+<div class="landing whitepart">
+    <h1>Stream or DCB, the same decider</h1>
+    <p class="center comparecaption">Same <code>decide</code> and <code>evolve</code>. A DCB decider adds the consistency boundary the command reads and the tags for the events it writes, so a rule can span more than one entity without a shared stream.</p>
+    <div class="compare">
+        <div class="compare-col">
+            <h3 class="center">Stream</h3>
+            {% include kotlinSnippet.html kotlin=streamDecider %}
+        </div>
+        <div class="compare-col">
+            <h3 class="center">DCB</h3>
+            {% include kotlinSnippet.html kotlin=dcbDecider %}
+        </div>
+    </div>
+</div>
+
 <div class="landing whitepart">
     <h1>What is Occurrent?</h1>
     <div class="boxes">


### PR DESCRIPTION
Replace the hand-rolled ApplicationService in the landing hero with the idiomatic path (a pure domain function passed to the built-in GenericApplicationService), and add a 'Stream or DCB, the same decider' section comparing a stream Decider and a DcbDecider side by side. Kotlin only for the comparison, since execute(command, decider) is a Kotlin extension with no Java one-liner. New kotlinSnippet.html include plus responsive, equal-height two-column CSS.