### PR TITLE
Document the Java decider facades (hold for next release)

### DIFF
--- a/_includes/kotlinSnippet.html
+++ b/_includes/kotlinSnippet.html
@@ -1,3 +1,0 @@
-<div class="single-snippet" markdown="1">
-~~~kotlin{{include.kotlin}}~~~
-</div>

--- a/_includes/landing.css
+++ b/_includes/landing.css
@@ -279,32 +279,32 @@ nav ul li a:hover {
     text-transform: none;
 }
 
-/* Stretch the code block to fill the column so both backgrounds line up even when
-   one example has more lines than the other. */
-.compare-col .single-snippet {
+/* Each cell is a docsSnippet with Java/Kotlin tabs. Stretch the active tab's code block to
+   fill the column so the two cards stay equal height regardless of line count. */
+.compare-col .multitab-code {
     flex: 1;
-    display: flex;
-}
-
-.compare-col .single-snippet .highlighter-rouge {
-    flex: 1;
-    margin: 0;
     display: flex;
     flex-direction: column;
+    margin-top: 0;
 }
 
-.compare-col .single-snippet .highlight {
+.compare-col .multitab-code > div[data-tab] {
     flex: 1;
+    min-height: 0;
 }
 
-.compare .single-snippet pre {
+.compare-col .multitab-code .highlighter-rouge,
+.compare-col .multitab-code .highlight {
+    height: 100%;
     margin: 0;
-    border-radius: 5px;
+}
+
+.compare .multitab-code pre {
     height: 100%;
     box-sizing: border-box;
 }
 
-.compare .single-snippet pre code {
+.compare .multitab-code pre code {
     font-size: 13px;
 }
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -2900,16 +2900,20 @@ It's possible to integrate [Decider's](#decider) with an [ApplicationService](#a
 
 ### Java<a id="application-service-decider-java"></a>
 
-To use the existing [ApplicationService](#application-service) infrastructure with Deciders from Java, you can do like this:
-
+To use the existing [ApplicationService](#application-service) infrastructure with Deciders from Java, wrap it in a `DeciderApplicationService`, the Java counterpart to the Kotlin `execute(streamId, command, decider)` extension:
 
 ```java
 ApplicationService<Event> applicationService = ...
 Command command = ...
 
-// The decider works with a List<Event>, which is exactly what the ApplicationService now expects,
-// so you can pass the decision function straight to execute.
-var writeResult = applicationService.execute("streamId", events -> decider.decideOnEventsAndReturnEvents(events, defineName));
+var deciderApplicationService = new DeciderApplicationService<>(applicationService);
+var writeResult = deciderApplicationService.execute("streamId", command, decider);
+```
+
+The decider's event type must match the application service's event type. If the decider only handles a subset of the events, for example one feature's events while the application service handles them all, convert it to the service's event type first with `Decider.adapt(...)`. If you would rather not introduce the facade, the decider works with a `List<Event>`, which is exactly what the `ApplicationService` expects, so you can pass the decision function straight to `execute`:
+
+```java
+var writeResult = applicationService.execute("streamId", events -> decider.decideOnEventsAndReturnEvents(events, command));
 ```
 
 
@@ -3221,7 +3225,7 @@ val tagGenerator: TagGenerator<StudentEnrolledInCourse> = AnnotationTagGenerator
 
 A `DcbDecider` couples three things a feature would otherwise have to keep in sync by hand: the plain `Decider` (decide and evolve), a function from command to the `DcbCriteria` boundary that command needs, and a `TagGenerator` for the events it emits. Build one with `DcbDecider.create(...)` (or `DcbDecider.from` around an existing `Decider`), or the Kotlin `dcbDecider(...)` factory, which reads a little more naturally at the call site. In Kotlin you can also turn an existing `Decider` into a `DcbDecider` with the `toDcb { ... }` extension, supplying the `criteria` and `tags` for the boundary.
 
-Once a decider is a `DcbDecider`, it is self-describing: given a command, it knows both what to decide and where to read from. The Kotlin DSL's `execute(command, dcbDecider)` puts that to work directly: it asks the decider for the command's boundary, reads the matching events, decides, tags the new events with the decider's own `TagGenerator`, and appends, all without you naming a `DcbCriteria` at the call site.
+Once a decider is a `DcbDecider`, it is self-describing: given a command, it knows both what to decide and where to read from. Running it is a single call, the Kotlin DSL's `execute(command, dcbDecider)` or, from Java, a `DcbDeciderApplicationService` wrapping the DCB application service. Either one asks the decider for the command's boundary, reads the matching events, decides, tags the new events with the decider's own `TagGenerator`, and appends, all without you naming a `DcbCriteria` at the call site.
 
 {% capture java %}
 DcbDecider<EnrollStudent, EnrollmentState, DomainEvent> enrollmentDecider = DcbDecider.create(
@@ -3232,8 +3236,11 @@ DcbDecider<EnrollStudent, EnrollmentState, DomainEvent> enrollmentDecider = DcbD
         event -> tagsFor(event)
 );
 
-// The decider knows its own read boundary for a given command
-DcbCriteria boundary = enrollmentDecider.criteria().apply(new EnrollStudent(courseId, studentId));
+// DcbDeciderApplicationService resolves the boundary, decides, tags, and appends in one call
+var deciderApplicationService = new DcbDeciderApplicationService<>(applicationService);
+Optional<DcbAppendResult> result = deciderApplicationService.execute(
+        new EnrollStudent(courseId, studentId),
+        enrollmentDecider);
 {% endcapture %}
 {% capture kotlin %}
 val enrollmentDcbDecider: DcbDecider<EnrollStudent, EnrollmentState, DomainEvent> = dcbDecider(

--- a/pages/index.md
+++ b/pages/index.md
@@ -17,20 +17,35 @@ permalink: /
     </div>
 </div>
 
-{% capture streamDecider %}
+{% capture streamKotlin %}
 // One boundary per stream
 val game = Decider.create(
     initialState, ::decide, ::evolve
 )
 applicationService.execute(gameId, command, game)
 {% endcapture %}
-{% capture dcbDecider %}
-// A boundary per decision, across entities
+{% capture streamJava %}
+// One boundary per stream
+var game = Decider.create(
+    initialState, this::decide, this::evolve
+);
+deciderApplicationService.execute(gameId, command, game);
+{% endcapture %}
+{% capture dcbKotlin %}
+// A boundary you define per decision, across entities
 val game = DcbDecider.create(
     initialState, ::decide, ::evolve,
     ::boundaryFor, ::tagsFor
 )
 dcbApplicationService.execute(command, game)
+{% endcapture %}
+{% capture dcbJava %}
+// A boundary you define per decision, across entities
+var game = DcbDecider.create(
+    initialState, this::decide, this::evolve,
+    this::boundaryFor, this::tagsFor
+);
+dcbDeciderApplicationService.execute(command, game);
 {% endcapture %}
 
 <div class="landing whitepart">
@@ -39,11 +54,11 @@ dcbApplicationService.execute(command, game)
     <div class="compare">
         <div class="compare-col">
             <h3 class="center">Stream</h3>
-            {% include kotlinSnippet.html kotlin=streamDecider %}
+            {% include macros/docsSnippet.html java=streamJava kotlin=streamKotlin %}
         </div>
         <div class="compare-col">
             <h3 class="center">DCB</h3>
-            {% include kotlinSnippet.html kotlin=dcbDecider %}
+            {% include macros/docsSnippet.html java=dcbJava kotlin=dcbKotlin %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Documents the new Java decider facades (`DeciderApplicationService`, `DcbDeciderApplicationService`) that let Java run a `Decider` or `DcbDecider` in one call, the counterpart to the Kotlin `execute(command, decider)` extensions.

- Landing "Stream or DCB" comparison: adds a Java tab to both columns. It was Kotlin only because Java had no one-call form, which is now fixed. The cells switched to the tabbed snippet and the equal-height CSS moved with them.
- Decider docs: the stream Java section leads with `DeciderApplicationService`, and the "Coupling a Decider to a Boundary" Java tab now runs the `DcbDecider` via `DcbDeciderApplicationService` rather than only reading its boundary.

Do not merge yet. The facades are on occurrent `main` but not in a published release, so hold this until the next release ships so the docs match what users can actually depend on.
