### PR TITLE
Document the Saga DSL (hold for next release)

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1645,8 +1645,7 @@ For synchronous side effects, prefer `sideEffect(...)` or `options().sideEffect(
 ## Sagas
 
 A "saga" can be used to represent and coordinate a long-lived business transaction/process (where "long-lived" is kind of arbitrary). This is an advanced subject
-and you should try to avoid sagas if there are other means available to solve the problem (for example use [policies](#policy) if they are sufficient). Occurrent doesn't provide or enforce any specific
-Saga implementation. But since Occurrent is a library you can hook in already existing solutions, for example:   
+and you should try to avoid sagas if there are other means available to solve the problem (for example use [policies](#policy) if they are sufficient, or [DCB](#dcb) when two rules must hold in one append). When you do need one, Occurrent now ships a built-in [Saga DSL](#saga-dsl) that describes the process as data and runs it against a subscription. If the built-in DSL doesn't fit your needs, Occurrent is a library, so you can also hook in an existing solution, for example:   
 
 * [Temporal](https://temporal.io/) - Open source microservices orchestration platform for running mission critical code at any scale.
 * [zio-saga](https://github.com/VladKopanev/zio-saga) - If you're using [Scala](https://scala-lang.org/) and [zio](https://zio.dev/)  (there's also a [cats implementation](https://github.com/VladKopanev/cats-saga)).

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -103,6 +103,13 @@ permalink: /documentation
 * * [Subscription DSL](#subscription-dsl)
 * * [Query DSL](#query-dsl)
 * * * [DCB Query DSL](#dcb-query-dsl)
+* * [Saga DSL](#saga-dsl)
+* * * [The Machine Core](#saga-machine-core)
+* * * [The Flow DSL](#saga-flow-dsl)
+* * * [Effects Are Data](#saga-effects)
+* * * [Running a Saga](#running-a-saga)
+* * * [The `@Saga` Annotation](#the-saga-annotation)
+* * * [Delivery Contract](#saga-delivery-contract)
 * [Spring Boot Starter](#spring-boot-starter)
 * * [Reactive Spring Boot Starter](#reactive-spring-boot-starter)
 * * [Annotations](#spring-boot-annotations)
@@ -3611,6 +3618,252 @@ occurrent:
 
 You can code-complete the available properties in Intellij or have a look at [org.occurrent.springboot.mongo.blocking.OccurrentProperties](https://github.com/johanhaleby/occurrent/blob/occurrent-{{site.occurrentversion}}/framework/spring-boot-starter-mongodb/src/main/java/org/occurrent/springboot/mongo/blocking/OccurrentProperties.java)
 to find which configuration properties that are supported.
+
+## Saga DSL
+
+A saga (more precisely a process manager) reacts to events, and to their absence over time, by issuing commands. It is the write side's answer to a process that spans more than one stream and unfolds over real time, such as "cancel the order if payment is not reserved within 30 minutes". The `Saga<E, S, C>` descriptor is the dual of a [decider](#decider). A decider turns commands into events, a saga turns events (and its own timeouts) into commands. Like a decider it is pure data and pure functions, so it unit-tests with plain equality assertions on the effects it returns, no infrastructure involved.
+
+Here is the order-fulfillment process. `OrderPlaced` reserves payment and arms a 30-minute timer, `PaymentReserved` ships the order, `PaymentFailed` cancels it, and the timer firing (nobody reserved or failed the payment in time) also cancels it:
+
+{% capture kotlin %}
+val orderFulfillment: Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> =
+    saga {
+        startsOn<OrderPlaced>(correlatedBy = { it.orderId }) { order ->
+            issue(ReservePayment(order.orderId, order.amount))
+        }
+        correlate<PaymentReserved> { it.orderId }
+        correlate<PaymentFailed> { it.orderId }
+        step("awaiting-payment") {
+            on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
+            on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
+            timeout(within = Duration.ofMinutes(30), then = end) { received ->
+                issue(CancelOrder(received.initiating(OrderPlaced::class.java).orderId, "payment timeout"))
+            }
+        }
+    }
+{% endcapture %}
+{% capture java %}
+Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> orderFulfillment =
+        FlowSaga.<OrderEvent, OrderCommand>builder()
+                .startsOn(OrderPlaced.class, OrderPlaced::orderId,
+                        order -> List.of(new ReservePayment(order.orderId(), order.amount())))
+                .correlate(PaymentReserved.class, PaymentReserved::orderId)
+                .correlate(PaymentFailed.class, PaymentFailed::orderId)
+                .step("awaiting-payment", step -> step
+                        .on(PaymentReserved.class, Continuation.end(),
+                                payment -> List.of(new ShipOrder(payment.orderId())))
+                        .on(PaymentFailed.class, Continuation.end(),
+                                failure -> List.of(new CancelOrder(failure.orderId(), failure.reason())))
+                        .timeout(Duration.ofMinutes(30), Continuation.end(),
+                                received -> List.of(new CancelOrder(received.initiating(OrderPlaced.class).orderId(), "payment timeout"))))
+                .build();
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+A saga is not a substitute for a [Dynamic Consistency Boundary](#dynamic-consistency-boundary). When two rules must hold atomically in one append, express both as a single `DcbCriteria` and let one decider decide against them together, which is cheaper and stronger. Reach for a saga only when the process is genuinely cross-boundary and time-involving. The "cancel if payment is not reserved within 30 minutes" rule has no single append at which both facts are known, because the payment may simply never arrive and the deciding write has to be triggered by the passage of time rather than by an event. That is the gap a saga fills, and the only one.
+
+There are two ways to author a saga, and both compile to the same `Saga<E, S, C>` descriptor, so the runner only ever runs one kind of thing. The flow DSL above is the sugar for the common case, a linear process moving through a few named steps. Underneath it is the machine core, an explicit per-event-type fold and reaction. Use the flow DSL when your process is a small sequence of steps, drop to the machine core when it is not.
+
+### The Machine Core {#saga-machine-core}
+
+The machine core is `Saga.builder(initialState)` in Java and `saga(initialState) { }` in Kotlin. You register, per event type, an `evolve` that folds the event into state and a `react` that decides what to do now that the event has been applied. Timers get their own `evolveOnTimeout` and `reactOnTimeout`, keyed by name. `evolve` and `react` are kept separate on purpose. Rehydrating an instance from history calls only `evolve`, so replay can never re-issue a command.
+
+Here is the same order-fulfillment process as the flow example above, written against an explicit `OrderSagaState`:
+
+{% capture kotlin %}
+val orderFulfillment = saga<OrderEvent, OrderSagaState?, OrderCommand>(initialState = null) {
+    correlateAll { it.orderId }
+    startsOn<OrderPlaced>()
+    evolve<OrderPlaced> { _, e -> AwaitingPayment(e.orderId) }
+    react<OrderPlaced> { _, e ->
+        issue(ReservePayment(e.orderId, e.amount))
+        startTimeout("payment", Duration.ofMinutes(30))
+    }
+    evolve<PaymentReserved> { _, e -> Completed(e.orderId) }
+    react<PaymentReserved> { _, e ->
+        issue(ShipOrder(e.orderId))
+        cancelTimeout("payment")
+    }
+    evolve<PaymentFailed> { _, e -> Cancelled(e.orderId, e.reason) }
+    react<PaymentFailed> { _, e ->
+        issue(CancelOrder(e.orderId, e.reason))
+        cancelTimeout("payment")
+    }
+    evolveOnTimeout("payment") { _, t -> Cancelled(t.sagaId, "payment timeout") }
+    reactOnTimeout("payment") { _, t -> issue(CancelOrder(t.sagaId, "payment timeout")) }
+    isTerminal { it is Completed || it is Cancelled }
+}
+{% endcapture %}
+{% capture java %}
+Saga<OrderEvent, OrderSagaState, OrderCommand> orderFulfillment =
+        Saga.<OrderEvent, OrderSagaState, OrderCommand>builder(null)
+                .correlateAll(OrderEvent::orderId)
+                .startsOn(OrderPlaced.class)
+                .evolve(OrderPlaced.class, (state, e) -> new AwaitingPayment(e.orderId()))
+                .react(OrderPlaced.class, (state, e) -> List.of(
+                        SagaEffect.issue(new ReservePayment(e.orderId(), e.amount())),
+                        SagaEffect.startTimeout("payment", Duration.ofMinutes(30))))
+                .evolve(PaymentReserved.class, (state, e) -> new Completed(e.orderId()))
+                .react(PaymentReserved.class, (state, e) -> List.of(
+                        SagaEffect.issue(new ShipOrder(e.orderId())),
+                        SagaEffect.cancelTimeout("payment")))
+                .evolve(PaymentFailed.class, (state, e) -> new Cancelled(e.orderId(), e.reason()))
+                .react(PaymentFailed.class, (state, e) -> List.of(
+                        SagaEffect.issue(new CancelOrder(e.orderId(), e.reason())),
+                        SagaEffect.cancelTimeout("payment")))
+                .evolveOnTimeout("payment", (state, t) -> new Cancelled(t.sagaId(), "payment timeout"))
+                .reactOnTimeout("payment", (state, t) -> List.of(SagaEffect.issue(new CancelOrder(t.sagaId(), "payment timeout"))))
+                .isTerminal(state -> state instanceof Completed || state instanceof Cancelled)
+                .build();
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+`correlateAll` (or a per-type `correlate`) says which instance an event belongs to, returned as a plain `String` id. `startsOn` names the event types that create a new instance. An event that correlates to no existing instance and is not a start event is skipped rather than starting one on the wrong event. `build()` fails loudly if any handled event type has no correlation rule, so "event arrived, no idea which instance" cannot happen at run time. `isTerminal` marks the states that end the process. A terminal instance ignores further input, and the runner cancels its outstanding timers.
+
+The flow DSL cannot express everything, on purpose. It has no dynamic N-of-M joins, no accumulators across steps, and no "this event is valid in every step" matching. A process that needs any of those drops to the machine core, where `evolve` and `react` can express them directly.
+
+### The Flow DSL {#saga-flow-dsl}
+
+The flow DSL describes a process as a linear sequence of named steps. A step is either a set of `on(...)` branches (first match wins) or a single `join(...)`, and it can carry a `timeout(...)`. Each branch and timeout names where the saga goes next through a `Continuation`. `end` completes the saga, `next` advances to the following step, and `goTo("step")` jumps (a back-edge models a retry loop). The whole step graph is validated at `build()` time, so a `goTo` to a step that does not exist is a build error, not a run-time surprise.
+
+The order-fulfillment example above is the shape to copy for a branch-and-timeout step. For a timeout on its own, here is the "close the game if no player joins within 10 minutes" case:
+
+{% capture kotlin %}
+val gameLobby = saga<GameEvent, CloseGame> {
+    startsOn<GameCreated>(correlatedBy = { it.gameId })
+    correlate<PlayerJoined> { it.gameId }
+    step("awaiting-players") {
+        on<PlayerJoined>(then = end) { }
+        timeout(within = Duration.ofMinutes(10), then = end) { received ->
+            issue(CloseGame(received.initiating(GameCreated::class.java).gameId))
+        }
+    }
+}
+{% endcapture %}
+{% capture java %}
+Saga<GameEvent, FlowState<GameEvent>, CloseGame> gameLobby =
+        FlowSaga.<GameEvent, CloseGame>builder()
+                .startsOn(GameCreated.class, GameCreated::gameId)
+                .correlate(PlayerJoined.class, PlayerJoined::gameId)
+                .step("awaiting-players", step -> step
+                        .on(PlayerJoined.class, Continuation.end(), player -> List.of())
+                        .timeout(Duration.ofMinutes(10), Continuation.end(),
+                                received -> List.of(new CloseGame(received.initiating(GameCreated.class).gameId()))))
+                .build();
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+A flow reaction reads `ReceivedEvents`, the events this instance has seen so far with the initiating event first. `received.initiating(GameCreated.class)` gets the start event back to build the command from. A `timeout(within = ...)` fires after a relative duration, and `timeout(at = { received -> ... })` fires at an absolute `Instant` you compute from the received events, an auction's end time for example.
+
+### Effects Are Data {#saga-effects}
+
+A reaction never performs an effect. It returns a list of `SagaEffect` values and the runner interprets them. There are four:
+
+* `issue(command)` hands a command to the dispatcher. It carries no routing information, because a command already carries the id of whatever it targets.
+* `startTimeout(name, Duration)` arms (or re-arms) a named timer to fire after a relative duration.
+* `startTimeoutAt(name, Instant)` arms a timer for an absolute, data-derived instant.
+* `cancelTimeout(name)` cancels a running timer, a no-op if none is running.
+
+Timers use `Duration` and `Instant`, never the [deadline module](#deadlines). Keeping effects as plain data is what makes a reaction pure. A relative `Duration` is resolved against the clock by the runner when it stores the timer, not inside `react`, so the same reaction returns the same effect values every time and you can assert on them with plain equality.
+
+### Running a Saga {#running-a-saga}
+
+Programmatically, `SagaRunner` is the write-side mirror of the read-side [`ProjectionRunner`](#views). It subscribes to the saga's events, folds and persists per-instance state, dispatches the commands each reaction issues, and polls the state store to fire timers. Pick the capability with the factory. `agnostic(...)` delivers both stream-written and DCB-appended events, `stream(...)` only stream-written ones:
+
+{% capture java %}
+SagaStateStore<OrderSagaState> stateStore = SagaStateStore.inMemory();
+CommandDispatcher<OrderCommand> dispatcher = command ->
+        applicationService.execute(command.orderId(), events -> handle(events, command));
+
+SagaSubscription subscription = SagaRunner.agnostic(subscriptionModel, cloudEventConverter)
+        .run("order-fulfillment", orderFulfillment, stateStore, dispatcher);
+{% endcapture %}
+{% include macros/docsSnippet.html java=java %}
+
+The dispatcher is a `CommandDispatcher`, usually just a lambda over an `ApplicationService`. The decider-free path above is first-class, you hand each command to any `ApplicationService`-shaped receiver. When the command target is a decider, `CommandDispatchers.decider(...)` wires it for you:
+
+{% capture java %}
+CommandDispatcher<OrderCommand> dispatcher =
+        CommandDispatchers.decider(deciderApplicationService, orderCommandDecider, OrderCommand::orderId);
+{% endcapture %}
+{% include macros/docsSnippet.html java=java %}
+
+The `SagaStateStore` persists each instance. `SagaStateStore.inMemory()` is for tests and single-node use, and `SpringMongoSagaStateStore` (in the blocking MongoDB starter) is the durable one. Unlike a read-model store it supports a compare-and-set save, because an event and a timer can touch the same instance concurrently, so the runner detects a lost update and retries instead of overwriting. Timers live in the same stored envelope as the state, not in an external scheduler. A timer poller inside the runner periodically reads instances with a due timer and re-enters them through the same pipeline a live event uses. That means no deadline or JobRunr infrastructure to run, at the cost of firing precision bounded by the poll interval, which does not matter at the minutes-to-days timescale sagas work on.
+
+### The `@Saga` Annotation {#the-saga-annotation}
+
+On the [Spring Boot starter](#spring-boot-starter) you do not wire a `SagaRunner` yourself. Annotate a no-arg factory method returning a `Saga` with `org.occurrent.annotation.Saga` and the framework registers it as a managed saga, subscribing through the same catch-up, durable-resume, and [competing-consumer](#competing-consumer-subscription-blocking) machinery as [`@Subscription`](#spring-boot-annotations):
+
+{% capture kotlin %}
+import org.occurrent.annotation.Saga
+
+@Component
+class OrderFulfillmentSaga {
+
+    @Saga(id = "order-fulfillment")
+    fun orderFulfillment() = saga {
+        startsOn<OrderPlaced>(correlatedBy = { it.orderId }) { order ->
+            issue(ReservePayment(order.orderId, order.amount))
+        }
+        correlate<PaymentReserved> { it.orderId }
+        correlate<PaymentFailed> { it.orderId }
+        step("awaiting-payment") {
+            on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
+            on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
+            timeout(within = Duration.ofMinutes(30), then = end) { received ->
+                issue(CancelOrder(received.initiating(OrderPlaced::class.java).orderId, "payment timeout"))
+            }
+        }
+    }
+}
+{% endcapture %}
+{% capture java %}
+import org.occurrent.annotation.Saga;
+
+@Component
+class OrderFulfillmentSaga {
+
+    @Saga(id = "order-fulfillment")
+    org.occurrent.dsl.saga.Saga<OrderEvent, OrderSagaState, OrderCommand> orderFulfillment() {
+        return org.occurrent.dsl.saga.Saga.<OrderEvent, OrderSagaState, OrderCommand>builder(null)
+                .correlateAll(OrderEvent::orderId)
+                .startsOn(OrderPlaced.class)
+                .evolve(OrderPlaced.class, (state, e) -> new AwaitingPayment(e.orderId()))
+                .react(OrderPlaced.class, (state, e) -> List.of(
+                        SagaEffect.issue(new ReservePayment(e.orderId(), e.amount())),
+                        SagaEffect.startTimeout("payment", Duration.ofMinutes(30))))
+                // ...the rest of the folds and reactions from the machine-core example above
+                .isTerminal(state -> state instanceof Completed || state instanceof Cancelled)
+                .build();
+    }
+}
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+The annotation and the DSL descriptor share the name `Saga`, so a Java factory method has to qualify one of them, as above. Kotlin has no such clash, since the DSL entry point is the lowercase `saga` function and the return type can be inferred.
+
+`@Saga` takes:
+
+| Attribute | Description |
+|:----------|:-------------|
+| `id` | The durable subscription and checkpoint key (required). |
+| `startAt` | `StartPosition.BEGINNING`, `NOW`, or `DEFAULT`, the same start-position idea as [`@Subscription`](#subscription-start-position). |
+| `startAtGlobalPosition` | Start after a specific global position instead, to rewind a saga to a known point. Mutually exclusive with a non-default `startAt`. |
+| `resumeBehavior` | `DEFAULT` or `SAME_AS_START_AT`, the same [resume-behavior idea](#subscription-start-position) as `@Subscription`. |
+| `startupMode` | `DEFAULT`, `WAIT_UNTIL_STARTED`, or `BACKGROUND`, the same [startup-mode idea](#subscription-startup-mode) as `@Subscription`. |
+| `capability` | `AGNOSTIC` (both stream and DCB events) or `STREAM` (stream events only). |
+| `store` / `storeName` | Select the `SagaStateStore` bean by type or name. With both unset the store resolves by convention, the unique `SagaStateStore` bean, otherwise a zero-config MongoDB store in a `saga-<id>` collection. |
+| `commandDispatcher` / `commandDispatcherName` | Select the `CommandDispatcher` bean by type or name, otherwise the unique `CommandDispatcher` bean. There is no default dispatcher, since it is usually a lambda over your `ApplicationService`. |
+
+`@Saga` is blocking-only in this first version, the reactive starter does not register it.
+
+### Delivery Contract {#saga-delivery-contract}
+
+Command dispatch is at-least-once. The runner dispatches a reaction's commands before it saves the resulting state, so a crash between the two, or a compare-and-set retry after a concurrent write, can dispatch the same command twice, but never lose one. This is safe when the receiver is idempotent, which an `ApplicationService`-backed dispatcher is by construction. It re-folds the authoritative event stream on every call, so the target's own invariants reject a stale or already-applied command and a duplicate becomes a no-op. Timer bookkeeping has no such gap, because `startTimeout` and `cancelTimeout` are saved atomically with the rest of the state in the same write, so timers are exactly-once.
+
+A flow saga remembers the events it has received (joins, guards, and timeouts read them), so those events are persisted. They serialize as CloudEvents through the application's `CloudEventConverter`, which means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name. A domain event can therefore move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
+
+For the full design rationale, including the residual cross-node race a compare-and-set retry can produce and the deferred outbox that would make dispatch exactly-once, see [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md). The complete, runnable [order-fulfillment example](https://github.com/johanhaleby/occurrent/tree/occurrent-{{site.occurrentversion}}/example/saga/order-fulfillment) has both authoring surfaces wired through `SagaRunner` with both dispatcher styles.
 
 ## Reactive Spring Boot Starter
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3755,6 +3755,21 @@ Saga<GameEvent, FlowState<GameEvent>, CloseGame> gameLobby =
 
 A flow reaction reads `ReceivedEvents`, the events this instance has seen so far with the initiating event first. In Kotlin `received.initiating<GameCreated>()` gets the start event back to build the command from (Java uses `received.initiating(GameCreated.class)`), and `first`, `all`, and `count` have the same reified form. A `timeout(after = ...)` fires once a relative duration has elapsed, and `timeout(at = { received -> ... })` fires at an absolute `Instant` you compute from the received events, an auction's end time for example.
 
+A step is either a set of `on(...)` branches or a single `join(...)`, never both. A join waits until every `Expectation` it lists is met, counted since the step was entered, then runs once and follows its `Continuation`. Here is a step that waits for both players in the lobby above to ready up before it advances:
+
+{% capture kotlin %}
+step("waiting-for-both-players") {
+    join(expect<PlayerReady>(2), then = next) { }
+}
+{% endcapture %}
+{% capture java %}
+.step("waiting-for-both-players", step -> step
+        .join(List.of(Expectation.of(PlayerReady.class, 2)), Continuation.next(), received -> List.of()))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+`startsOn` and `correlate` register into the same correlation map, so calling `startsOn` for a type already registered via `correlate` (or the reverse) throws `IllegalStateException` instead of silently overwriting the earlier registration. Register each event type's correlation exactly once, whichever of the two you use.
+
 ### Effects Are Data {#saga-effects}
 
 A reaction never performs an effect. It returns a list of `SagaEffect` values and the runner interprets them. There are four:
@@ -3766,10 +3781,41 @@ A reaction never performs an effect. It returns a list of `SagaEffect` values an
 
 Timers use `Duration` and `Instant`, never the [deadline module](#deadlines). Keeping effects as plain data is what makes a reaction pure. A relative `Duration` is resolved against the clock by the runner when it stores the timer, not inside `react`, so the same reaction returns the same effect values every time and you can assert on them with plain equality.
 
+Here are all three effects in play: reserving payment issues a command and arms the payment timer, reserving it successfully issues another command and disarms that same timer:
+
+{% capture kotlin %}
+react<OrderPlaced> { _, e ->
+    issue(ReservePayment(e.orderId, e.amount))
+    startTimeout("payment", Duration.ofMinutes(30))
+}
+react<PaymentReserved> { _, e ->
+    issue(ShipOrder(e.orderId))
+    cancelTimeout("payment")
+}
+{% endcapture %}
+{% capture java %}
+.react(OrderPlaced.class, (state, e) -> List.of(
+        SagaEffect.issue(new ReservePayment(e.orderId(), e.amount())),
+        SagaEffect.startTimeout("payment", Duration.ofMinutes(30))))
+.react(PaymentReserved.class, (state, e) -> List.of(
+        SagaEffect.issue(new ShipOrder(e.orderId())),
+        SagaEffect.cancelTimeout("payment")))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
 ### Running a Saga {#running-a-saga}
 
-Programmatically, `SagaRunner` is the write-side mirror of the read-side [`ProjectionRunner`](#views). It subscribes to the saga's events, folds and persists per-instance state, dispatches the commands each reaction issues, and polls the state store to fire timers. Pick the capability with the factory. `agnostic(...)` delivers both stream-written and DCB-appended events, `stream(...)` only stream-written ones:
+Programmatically, `SagaRunner` is the write-side mirror of the read-side [`ProjectionRunner`](#views). It subscribes to the saga's events, folds and persists per-instance state, dispatches the commands each reaction issues, and polls the state store to fire timers. Pick the capability with the factory. `agnostic(...)` delivers both stream-written and DCB-appended events, `stream(...)` only stream-written ones. There is no reactive `SagaRunner`, sagas run on the blocking stack only:
 
+{% capture kotlin %}
+val stateStore: SagaStateStore<OrderSagaState> = SagaStateStore.inMemory()
+val dispatcher = CommandDispatcher<OrderCommand> { command ->
+    applicationService.execute(command.orderId) { events -> handle(events, command) }
+}
+
+val subscription = SagaRunner.agnostic<OrderEvent, OrderCommand>(subscriptionModel, cloudEventConverter)
+    .run("order-fulfillment", orderFulfillment, stateStore, dispatcher)
+{% endcapture %}
 {% capture java %}
 SagaStateStore<OrderSagaState> stateStore = SagaStateStore.inMemory();
 CommandDispatcher<OrderCommand> dispatcher = command ->
@@ -3778,17 +3824,22 @@ CommandDispatcher<OrderCommand> dispatcher = command ->
 SagaSubscription subscription = SagaRunner.agnostic(subscriptionModel, cloudEventConverter)
         .run("order-fulfillment", orderFulfillment, stateStore, dispatcher);
 {% endcapture %}
-{% include macros/docsSnippet.html java=java %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 The dispatcher is a `CommandDispatcher`, usually just a lambda over an `ApplicationService`. The decider-free path above is first-class, you hand each command to any `ApplicationService`-shaped receiver. When the command target is a decider, `CommandDispatchers.decider(...)` wires it for you:
 
+{% capture kotlin %}
+val dispatcher = CommandDispatchers.decider(deciderApplicationService, orderCommandDecider) { it.orderId }
+{% endcapture %}
 {% capture java %}
 CommandDispatcher<OrderCommand> dispatcher =
         CommandDispatchers.decider(deciderApplicationService, orderCommandDecider, OrderCommand::orderId);
 {% endcapture %}
-{% include macros/docsSnippet.html java=java %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 The `SagaStateStore` persists each instance. `SagaStateStore.inMemory()` is for tests and single-node use, and `SpringMongoSagaStateStore` (in the blocking MongoDB starter) is the durable one. Unlike a read-model store it supports a compare-and-set save, because an event and a timer can touch the same instance concurrently, so the runner detects a lost update and retries instead of overwriting. Timers live in the same stored envelope as the state, not in an external scheduler. A timer poller inside the runner periodically reads instances with a due timer and re-enters them through the same pipeline a live event uses. That means no deadline or JobRunr infrastructure to run, at the cost of firing precision bounded by the poll interval, which does not matter at the minutes-to-days timescale sagas work on.
+
+Building a `SpringMongoSagaStateStore` by hand for a flow saga needs its four-argument constructor, with the application's `CloudEventConverter` passed alongside the state type. That converter is what lets the store serialize a `FlowState`'s retained events by their stable CloudEvent type rather than a Java class name. Passing `null`, or using the three-argument constructor, throws `IllegalArgumentException` rather than silently losing that package independence. A machine-core saga's state carries no such requirement, since it serializes with the application's own `MongoConverter`.
 
 ### The `@Saga` Annotation {#the-saga-annotation}
 
@@ -3859,9 +3910,24 @@ The annotation and the DSL descriptor share the name `Saga`, so a Java factory m
 
 ### Delivery Contract {#saga-delivery-contract}
 
-Command dispatch is at-least-once. The runner dispatches a reaction's commands before it saves the resulting state, so a crash between the two, or a compare-and-set retry after a concurrent write, can dispatch the same command twice, but never lose one. This is safe when the receiver is idempotent, which an `ApplicationService`-backed dispatcher is by construction. It re-folds the authoritative event stream on every call, so the target's own invariants reject a stale or already-applied command and a duplicate becomes a no-op. Timer bookkeeping has no such gap, because `startTimeout` and `cancelTimeout` are saved atomically with the rest of the state in the same write, so timers are exactly-once.
+Command dispatch is at-least-once. The runner dispatches a reaction's commands before it saves the resulting state, so a crash between the two, or a compare-and-set retry after a concurrent write, can dispatch the same command twice, but never lose one. This is safe when the receiver is idempotent, which an `ApplicationService`-backed dispatcher is by construction. It re-folds the authoritative event stream on every call, so the target's own invariants reject a stale or already-applied command and a duplicate becomes a no-op:
 
-A flow saga remembers the events it has received (joins, guards, and timeouts read them), so those events are persisted. They serialize as CloudEvents through the application's `CloudEventConverter`, which means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name. A domain event can therefore move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
+{% capture kotlin %}
+val dispatcher = CommandDispatchers.decider(deciderApplicationService, orderCommandDecider) { it.orderId }
+// A duplicate ReservePayment re-folds the stream and is rejected by the decider's own invariants, so it is a no-op.
+{% endcapture %}
+{% capture java %}
+CommandDispatcher<OrderCommand> dispatcher =
+        CommandDispatchers.decider(deciderApplicationService, orderCommandDecider, OrderCommand::orderId);
+// A duplicate ReservePayment re-folds the stream and is rejected by the decider's own invariants, so it is a no-op.
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+Timer bookkeeping has no such gap, because `startTimeout` and `cancelTimeout` are saved atomically with the rest of the state in the same write, so timers are exactly-once.
+
+A live event and a firing timer do not fail the same way when a `SagaConcurrencyException` exhausts its compare-and-set retries. On the event path the exception propagates to the subscription model, which redelivers the event and retries the whole step; the event is never lost, but the subscription is one ordered channel shared by every instance the saga handles, so an instance that keeps failing blocks the events queued behind it (head-of-line blocking) until it succeeds or the subscription is intervened on. On the timer path the poller catches the exception per instance, logs it, and leaves the timer due for the next poll, so other instances keep progressing and a stuck timer never blocks the poller. Because commands are dispatched before the save and a lost compare-and-set retries the step, a single input can also re-dispatch its whole command list several times, up to the configured `maxCasAttempts`, so a receiver has to tolerate more than plain at-least-once multiplicity.
+
+A flow saga does not remember its whole history. The received log a join, guard, or timeout reaction reads through `ReceivedEvents` is bounded to a configurable window: the current step's own events plus a carry-over of `historyWindow` earlier events, `FlowSaga.Builder.historyWindow(int events)` in Java, defaulting to 100 (the Kotlin flow builder does not yet expose the knob and always uses the default). The initiating event is always retained regardless of the window, since `received.initiating<T>()` is a common lookup, but anything older than the window is dropped and not persisted. Raise the window for a guard or join that needs to count back further than the default 100 events, or lower it to trim what a long-running instance persists. `FlowState`'s bookkeeping fields (`stepEntryIndex`, `previousStep`, `lastAction`, `matchedBranchIndex`, `windowStart`) are internal to the executor and are not a wire-format compatibility guarantee, unlike the retained domain events themselves, which serialize as CloudEvents through the application's `CloudEventConverter`. That means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name, so a domain event can move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
 
 For the full design rationale, including the residual cross-node race a compare-and-set retry can produce and the deferred outbox that would make dispatch exactly-once, see [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md). The complete, runnable [order-fulfillment example](https://github.com/johanhaleby/occurrent/tree/occurrent-{{site.occurrentversion}}/example/saga/order-fulfillment) has both authoring surfaces wired through `SagaRunner` with both dispatcher styles.
 
@@ -3869,7 +3935,23 @@ For the full design rationale, including the residual cross-node race a compare-
 
 A saga affects the outside world in exactly one way: it issues commands. There is no "call this API" effect, and that is deliberate, because it keeps `react` a pure function you can test with equality assertions. So a third-party call, whether it runs mid-process or as the last thing a completed saga does, is a command like any other. Write a reaction that issues, say, `NotifyWarehouse(orderId)`, and point that command at a dispatcher that makes the call. The terminal reaction, the one whose `Continuation` is `end`, is where a "now that the whole thing is done" effect belongs.
 
-Compensation works the same way. A saga does not roll back, it moves forward, so an "undo" is just another command you issue on the branch or timeout that detected the failure. The order-fulfillment saga above already does this. When payment fails or the timeout fires it issues `CancelOrder`, which is the compensation for the `ReservePayment` it issued earlier. You decide which command undoes which, there is no automatic inverse.
+Compensation works the same way. A saga does not roll back, it moves forward, so an "undo" is just another command you issue on the branch or timeout that detected the failure. The order-fulfillment saga above already does this. When payment fails or the timeout fires it issues `CancelOrder`, which is the compensation for the `ReservePayment` it issued earlier. You decide which command undoes which, there is no automatic inverse:
+
+{% capture kotlin %}
+on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
+timeout(after = Duration.ofMinutes(30), then = end) { received ->
+    issue(CancelOrder(received.initiating<OrderPlaced>().orderId, "payment timeout"))
+}
+{% endcapture %}
+{% capture java %}
+.on(PaymentFailed.class, Continuation.end(),
+        failure -> List.of(new CancelOrder(failure.orderId(), failure.reason())))
+.timeout(Duration.ofMinutes(30), Continuation.end(),
+        received -> List.of(new CancelOrder(received.initiating(OrderPlaced.class).orderId(), "payment timeout")))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+Both branches issue the same forward-moving `CancelOrder` compensation for the `ReservePayment` issued when the step started, whichever failure mode gets there first.
 
 The one thing to watch is idempotency, and it follows directly from the [delivery contract](#saga-delivery-contract). Command dispatch is at-least-once, so a compensating or external command can arrive twice. An `ApplicationService`-backed target handles that for free, because it re-folds the stream and the target's own invariants reject the duplicate. A raw third-party call does not. When a command triggers a non-idempotent external effect such as an email, a payment capture, or a partner request, give it a stable id derived from the saga and the triggering event, and dedupe at that boundary. The deferred document-local outbox described in [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md) would make dispatch exactly-once and remove this caveat, but it is not built yet.
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3726,7 +3726,7 @@ The flow DSL cannot express everything, on purpose. It has no dynamic N-of-M joi
 
 ### The Flow DSL {#saga-flow-dsl}
 
-The flow DSL describes a process as a linear sequence of named steps. A step is either a set of `on(...)` branches (first match wins) or a single `join(...)`, and it can carry a `timeout(...)`. Each branch and timeout names where the saga goes next through a `Continuation`. `end` completes the saga, `next` advances to the following step, and `goTo("step")` jumps (a back-edge models a retry loop). The whole step graph is validated at `build()` time, so a `goTo` to a step that does not exist is a build error, not a run-time surprise.
+The flow DSL describes a process as a linear sequence of named steps. A step is either a set of `on(...)` branches (first match wins) or a single `join(...)`, and it can carry a `timeout(...)`. Each branch and timeout names where the saga goes next through a `Continuation`. `end` completes the saga, `next` advances to the following step, and `transitionTo("step")` jumps (a back-edge models a retry loop). The whole step graph is validated at `build()` time, so a `transitionTo` to a step that does not exist is a build error, not a run-time surprise.
 
 The order-fulfillment example above is the shape to copy for a branch-and-timeout step. For a timeout on its own, here is the "close the game if no player joins within 10 minutes" case:
 
@@ -3767,6 +3767,33 @@ step("waiting-for-both-players") {
 {% capture java %}
 .step("waiting-for-both-players", step -> step
         .join(List.of(Expectation.of(PlayerReady.class, 2)), Continuation.next(), received -> List.of()))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+A `transitionTo` names any step, including the current one, which is how a flow expresses a loop. An auction stays open as long as bids keep arriving: each `BidPlaced` transitions the `bidding` step back to itself, and an absolute timeout closes it once its end time passes. Re-entering the step re-arms its timeout, but because the deadline is derived from the initiating event it stays pinned to the auction's end time rather than sliding forward on every bid:
+
+{% capture kotlin %}
+val auction = saga<AuctionEvent, CloseAuction> {
+    startsOn<AuctionStarted>(correlatedBy = { it.auctionId })
+    correlate<BidPlaced> { it.auctionId }
+    step("bidding") {
+        on<BidPlaced>(then = transitionTo("bidding")) { }
+        timeout(at = { received -> received.initiating<AuctionStarted>().endsAt }, then = end) { received ->
+            issue(CloseAuction(received.initiating<AuctionStarted>().auctionId))
+        }
+    }
+}
+{% endcapture %}
+{% capture java %}
+Saga<AuctionEvent, FlowState<AuctionEvent>, CloseAuction> auction =
+        FlowSaga.<AuctionEvent, CloseAuction>builder()
+                .startsOn(AuctionStarted.class, AuctionStarted::auctionId)
+                .correlate(BidPlaced.class, BidPlaced::auctionId)
+                .step("bidding", step -> step
+                        .on(BidPlaced.class, Continuation.transitionTo("bidding"), bid -> List.of())
+                        .timeout(received -> received.initiating(AuctionStarted.class).endsAt(), Continuation.end(),
+                                received -> List.of(new CloseAuction(received.initiating(AuctionStarted.class).auctionId()))))
+                .build();
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1647,8 +1647,10 @@ For synchronous side effects, prefer `sideEffect(...)` or `options().sideEffect(
 
 ## Sagas
 
+<div class="comment">As of version 0.31.0, Occurrent has its own <a href="#saga-dsl">Saga DSL</a> for writing event-driven process managers in code, with timers, correlation, and Spring wiring. Reach for it before the external libraries below.</div>
+
 A "saga" can be used to represent and coordinate a long-lived business transaction/process (where "long-lived" is kind of arbitrary). This is an advanced subject
-and you should try to avoid sagas if there are other means available to solve the problem (for example use [policies](#policy) if they are sufficient, or [DCB](#dcb) when two rules must hold in one append). When you do need one, Occurrent now ships a built-in [Saga DSL](#saga-dsl) that describes the process as data and runs it against a subscription. If the built-in DSL doesn't fit your needs, Occurrent is a library, so you can also hook in an existing solution, for example:   
+and you should try to avoid sagas if there are other means available to solve the problem (for example use [policies](#policy) if they are sufficient, or [DCB](#dcb) when two rules must hold in one append). If the built-in DSL doesn't fit your needs, Occurrent is a library, so you can also hook in an existing solution, for example:   
 
 * [Temporal](https://temporal.io/) - Open source microservices orchestration platform for running mission critical code at any scale.
 * [zio-saga](https://github.com/VladKopanev/zio-saga) - If you're using [Scala](https://scala-lang.org/) and [zio](https://zio.dev/)  (there's also a [cats implementation](https://github.com/VladKopanev/cats-saga)).

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -110,6 +110,7 @@ permalink: /documentation
 * * * [Running a Saga](#running-a-saga)
 * * * [The `@Saga` Annotation](#the-saga-annotation)
 * * * [Delivery Contract](#saga-delivery-contract)
+* * * [Side Effects and Compensation](#saga-side-effects)
 * [Spring Boot Starter](#spring-boot-starter)
 * * [Reactive Spring Boot Starter](#reactive-spring-boot-starter)
 * * [Annotations](#spring-boot-annotations)
@@ -3635,8 +3636,8 @@ val orderFulfillment: Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> =
         step("awaiting-payment") {
             on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
             on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
-            timeout(within = Duration.ofMinutes(30), then = end) { received ->
-                issue(CancelOrder(received.initiating(OrderPlaced::class.java).orderId, "payment timeout"))
+            timeout(after = Duration.ofMinutes(30), then = end) { received ->
+                issue(CancelOrder(received.initiating<OrderPlaced>().orderId, "payment timeout"))
             }
         }
     }
@@ -3733,8 +3734,8 @@ val gameLobby = saga<GameEvent, CloseGame> {
     correlate<PlayerJoined> { it.gameId }
     step("awaiting-players") {
         on<PlayerJoined>(then = end) { }
-        timeout(within = Duration.ofMinutes(10), then = end) { received ->
-            issue(CloseGame(received.initiating(GameCreated::class.java).gameId))
+        timeout(after = Duration.ofMinutes(10), then = end) { received ->
+            issue(CloseGame(received.initiating<GameCreated>().gameId))
         }
     }
 }
@@ -3752,7 +3753,7 @@ Saga<GameEvent, FlowState<GameEvent>, CloseGame> gameLobby =
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
-A flow reaction reads `ReceivedEvents`, the events this instance has seen so far with the initiating event first. `received.initiating(GameCreated.class)` gets the start event back to build the command from. A `timeout(within = ...)` fires after a relative duration, and `timeout(at = { received -> ... })` fires at an absolute `Instant` you compute from the received events, an auction's end time for example.
+A flow reaction reads `ReceivedEvents`, the events this instance has seen so far with the initiating event first. In Kotlin `received.initiating<GameCreated>()` gets the start event back to build the command from (Java uses `received.initiating(GameCreated.class)`), and `first`, `all`, and `count` have the same reified form. A `timeout(after = ...)` fires once a relative duration has elapsed, and `timeout(at = { received -> ... })` fires at an absolute `Instant` you compute from the received events, an auction's end time for example.
 
 ### Effects Are Data {#saga-effects}
 
@@ -3809,8 +3810,8 @@ class OrderFulfillmentSaga {
         step("awaiting-payment") {
             on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
             on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
-            timeout(within = Duration.ofMinutes(30), then = end) { received ->
-                issue(CancelOrder(received.initiating(OrderPlaced::class.java).orderId, "payment timeout"))
+            timeout(after = Duration.ofMinutes(30), then = end) { received ->
+                issue(CancelOrder(received.initiating<OrderPlaced>().orderId, "payment timeout"))
             }
         }
     }
@@ -3863,6 +3864,14 @@ Command dispatch is at-least-once. The runner dispatches a reaction's commands b
 A flow saga remembers the events it has received (joins, guards, and timeouts read them), so those events are persisted. They serialize as CloudEvents through the application's `CloudEventConverter`, which means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name. A domain event can therefore move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
 
 For the full design rationale, including the residual cross-node race a compare-and-set retry can produce and the deferred outbox that would make dispatch exactly-once, see [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md). The complete, runnable [order-fulfillment example](https://github.com/johanhaleby/occurrent/tree/occurrent-{{site.occurrentversion}}/example/saga/order-fulfillment) has both authoring surfaces wired through `SagaRunner` with both dispatcher styles.
+
+### Side Effects and Compensation {#saga-side-effects}
+
+A saga affects the outside world in exactly one way: it issues commands. There is no "call this API" effect, and that is deliberate, because it keeps `react` a pure function you can test with equality assertions. So a third-party call, whether it runs mid-process or as the last thing a completed saga does, is a command like any other. Write a reaction that issues, say, `NotifyWarehouse(orderId)`, and point that command at a dispatcher that makes the call. The terminal reaction, the one whose `Continuation` is `end`, is where a "now that the whole thing is done" effect belongs.
+
+Compensation works the same way. A saga does not roll back, it moves forward, so an "undo" is just another command you issue on the branch or timeout that detected the failure. The order-fulfillment saga above already does this. When payment fails or the timeout fires it issues `CancelOrder`, which is the compensation for the `ReservePayment` it issued earlier. You decide which command undoes which, there is no automatic inverse.
+
+The one thing to watch is idempotency, and it follows directly from the [delivery contract](#saga-delivery-contract). Command dispatch is at-least-once, so a compensating or external command can arrive twice. An `ApplicationService`-backed target handles that for free, because it re-folds the stream and the target's own invariants reject the duplicate. A raw third-party call does not. When a command triggers a non-idempotent external effect such as an email, a payment capture, or a partner request, give it a stable id derived from the saga and the triggering event, and dedupe at that boundary. The deferred document-local outbox described in [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md) would make dispatch exactly-once and remove this caveat, but it is not built yet.
 
 ## Reactive Spring Boot Starter
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -4003,19 +4003,21 @@ For the full design rationale, including the residual cross-node race a compare-
 
 Run several instances of your application and a saga has two things happening per instance: it receives events, and it polls the state store for due timers. The event side is already single-active when the subscription model is a [competing-consumer](#competing-consumer-subscription-blocking) one (the [Spring Boot starter](#spring-boot-starter) uses one by default), so for a given saga only one instance receives events at a time. The timer poller is separate. Left uncoordinated, every instance runs its own poller and queries the store for due timers on its own interval, so the timer-query load grows with the instance count even though only one instance needs to fire a due timer. Firing stays correct either way, since a lost compare-and-set is retried and the dispatch is idempotent, but the extra queries are wasted work.
 
-Give `SagaRunner.run` a `CompetingConsumerStrategy`, the same strategy the competing-consumer subscription uses, and the poller is gated too: it takes a lease and only polls while it holds it, so exactly one instance queries the store. The lease is keyed apart from the event subscription's own lease, and released when the `SagaSubscription` is closed, so another instance takes over within about one lease period. A standby instance checks whether it holds the lease in memory, so it costs no query at all:
+Give the `SagaRunner` a `CompetingConsumerStrategy` with `competingConsumerStrategy(...)`, the same strategy the competing-consumer subscription uses, and the poller is gated too: it takes a lease and only polls while it holds it, so exactly one instance queries the store. The lease is keyed apart from the event subscription's own lease, and released when the `SagaSubscription` is closed, so another instance takes over within about one lease period. A standby instance checks whether it holds the lease in memory, so it costs no query at all:
 
 {% capture kotlin %}
 val strategy = NativeMongoLeaseCompetingConsumerStrategy.withDefaults(mongoDatabase)
 
 val subscription = SagaRunner.agnostic<OrderEvent, OrderCommand>(subscriptionModel, cloudEventConverter)
-    .run("order-fulfillment", orderFulfillment, stateStore, dispatcher, null, SagaRunnerConfig.defaults(), strategy)
+    .competingConsumerStrategy(strategy)
+    .run("order-fulfillment", orderFulfillment, stateStore, dispatcher)
 {% endcapture %}
 {% capture java %}
 CompetingConsumerStrategy strategy = NativeMongoLeaseCompetingConsumerStrategy.withDefaults(mongoDatabase);
 
-SagaSubscription subscription = SagaRunner.agnostic(subscriptionModel, cloudEventConverter)
-        .run("order-fulfillment", orderFulfillment, stateStore, dispatcher, null, SagaRunnerConfig.defaults(), strategy);
+SagaSubscription subscription = SagaRunner.<OrderEvent, OrderCommand>agnostic(subscriptionModel, cloudEventConverter)
+        .competingConsumerStrategy(strategy)
+        .run("order-fulfillment", orderFulfillment, stateStore, dispatcher);
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -106,6 +106,7 @@ permalink: /documentation
 * * [Saga DSL](#saga-dsl)
 * * * [The Machine Core](#saga-machine-core)
 * * * [The Flow DSL](#saga-flow-dsl)
+* * * [Event Metadata](#saga-event-metadata)
 * * * [Effects Are Data](#saga-effects)
 * * * [Running a Saga](#running-a-saga)
 * * * [The `@Saga` Annotation](#the-saga-annotation)
@@ -3770,6 +3771,46 @@ step("waiting-for-both-players") {
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 `startsOn` and `correlate` register into the same correlation map, so calling `startsOn` for a type already registered via `correlate` (or the reverse) throws `IllegalStateException` instead of silently overwriting the earlier registration. Register each event type's correlation exactly once, whichever of the two you use.
+
+### Event Metadata {#saga-event-metadata}
+
+`evolve`, `react`, and `onStart` can also see the delivering event's metadata, its stream id and version, the global position, and any CloudEvent extension, through metadata-carrying overloads. This is the same [`EventMetadata`](#event-metadata) a plain subscription already hands a subscriber. A flow step's `on(...)` branch gets the same for its triggering event:
+
+{% capture kotlin %}
+react<PaymentReserved> { _, metadata, e ->
+    val position = metadata.position
+    val streamId = metadata.streamId
+    // Do stuff
+    issue(ShipOrder(e.orderId))
+    cancelTimeout("payment")
+}
+{% endcapture %}
+{% capture java %}
+.react(PaymentReserved.class, (state, metadata, e) -> {
+    Long position = metadata.getPosition();
+    String streamId = metadata.getStreamId();
+    // Do stuff
+    return List.of(
+            SagaEffect.issue(new ShipOrder(e.orderId())),
+            SagaEffect.cancelTimeout("payment"));
+})
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+A flow branch takes the metadata first, the same order the subscription DSL uses:
+
+{% capture kotlin %}
+on<PaymentReserved>(then = end) { metadata, payment ->
+    issue(ShipOrder(payment.orderId))
+}
+{% endcapture %}
+{% capture java %}
+.on(PaymentReserved.class, Continuation.end(),
+        (metadata, payment) -> List.of(new ShipOrder(payment.orderId())))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+Every event-only `evolve`, `react`, `onStart`, and flow `on(...)` keeps working unchanged, plain code never has to opt in to metadata. A saga does not persist metadata itself, only the events it folds into its own state, so if a reaction needs to remember something from the metadata beyond the current step, keep that slice in the saga's own state rather than relying on it being there later.
 
 ### Effects Are Data {#saga-effects}
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -110,6 +110,7 @@ permalink: /documentation
 * * * [Running a Saga](#running-a-saga)
 * * * [The `@Saga` Annotation](#the-saga-annotation)
 * * * [Delivery Contract](#saga-delivery-contract)
+* * * [Running Across Multiple Instances](#saga-multi-instance)
 * * * [Side Effects and Compensation](#saga-side-effects)
 * [Spring Boot Starter](#spring-boot-starter)
 * * [Reactive Spring Boot Starter](#reactive-spring-boot-starter)
@@ -3930,6 +3931,40 @@ A live event and a firing timer do not fail the same way when a `SagaConcurrency
 A flow saga does not remember its whole history. The received log a join, guard, or timeout reaction reads through `ReceivedEvents` is bounded to a configurable window: the current step's own events plus a carry-over of `historyWindow` earlier events, `FlowSaga.Builder.historyWindow(int events)` in Java, defaulting to 100 (the Kotlin flow builder does not yet expose the knob and always uses the default). The initiating event is always retained regardless of the window, since `received.initiating<T>()` is a common lookup, but anything older than the window is dropped and not persisted. Raise the window for a guard or join that needs to count back further than the default 100 events, or lower it to trim what a long-running instance persists. `FlowState`'s bookkeeping fields (`stepEntryIndex`, `previousStep`, `lastAction`, `matchedBranchIndex`, `windowStart`) are internal to the executor and are not a wire-format compatibility guarantee, unlike the retained domain events themselves, which serialize as CloudEvents through the application's `CloudEventConverter`. That means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name, so a domain event can move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
 
 For the full design rationale, including the residual cross-node race a compare-and-set retry can produce and the deferred outbox that would make dispatch exactly-once, see [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md). The complete, runnable [order-fulfillment example](https://github.com/johanhaleby/occurrent/tree/occurrent-{{site.occurrentversion}}/example/saga/order-fulfillment) has both authoring surfaces wired through `SagaRunner` with both dispatcher styles.
+
+### Running Across Multiple Instances {#saga-multi-instance}
+
+Run several instances of your application and a saga has two things happening per instance: it receives events, and it polls the state store for due timers. The event side is already single-active when the subscription model is a [competing-consumer](#competing-consumer-subscription-blocking) one (the [Spring Boot starter](#spring-boot-starter) uses one by default), so for a given saga only one instance receives events at a time. The timer poller is separate. Left uncoordinated, every instance runs its own poller and queries the store for due timers on its own interval, so the timer-query load grows with the instance count even though only one instance needs to fire a due timer. Firing stays correct either way, since a lost compare-and-set is retried and the dispatch is idempotent, but the extra queries are wasted work.
+
+Give `SagaRunner.run` a `CompetingConsumerStrategy`, the same strategy the competing-consumer subscription uses, and the poller is gated too: it takes a lease and only polls while it holds it, so exactly one instance queries the store. The lease is keyed apart from the event subscription's own lease, and released when the `SagaSubscription` is closed, so another instance takes over within about one lease period. A standby instance checks whether it holds the lease in memory, so it costs no query at all:
+
+{% capture kotlin %}
+val strategy = NativeMongoLeaseCompetingConsumerStrategy.withDefaults(mongoDatabase)
+
+val subscription = SagaRunner.agnostic<OrderEvent, OrderCommand>(subscriptionModel, cloudEventConverter)
+    .run("order-fulfillment", orderFulfillment, stateStore, dispatcher, null, SagaRunnerConfig.defaults(), strategy)
+{% endcapture %}
+{% capture java %}
+CompetingConsumerStrategy strategy = NativeMongoLeaseCompetingConsumerStrategy.withDefaults(mongoDatabase);
+
+SagaSubscription subscription = SagaRunner.agnostic(subscriptionModel, cloudEventConverter)
+        .run("order-fulfillment", orderFulfillment, stateStore, dispatcher, null, SagaRunnerConfig.defaults(), strategy);
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+On the [Spring Boot starter](#spring-boot-starter) this is on by default. A `@Saga` runner reuses the same `SpringMongoLeaseCompetingConsumerStrategy` the subscription model already builds, so nothing extra to wire. Both the poll interval and the gating are configurable under `occurrent.saga`:
+
+```yaml
+occurrent:
+  saga:
+    timer-poll-interval: 1s
+    competing-consumer:
+      enabled: true   # set to false to let every instance poll (the uncoordinated behavior)
+```
+
+Turn `competing-consumer.enabled` off, or run without a strategy, and the poller runs on every instance exactly as it did before. Single-node and in-memory setups need none of this.
+
+Gating removes the redundant queries. It does not change the residual cross-node race noted in the [delivery contract](#saga-delivery-contract) (an event on one instance interleaving with a timeout fired on another), which stays handled by compare-and-set and an idempotent receiver. See [ADR 0064](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0064-lease-gate-the-saga-timer-poller.md) for the full rationale.
 
 ### Side Effects and Compensation {#saga-side-effects}
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -104,7 +104,7 @@ permalink: /documentation
 * * [Query DSL](#query-dsl)
 * * * [DCB Query DSL](#dcb-query-dsl)
 * * [Saga DSL](#saga-dsl)
-* * * [The Machine Core](#saga-machine-core)
+* * * [The Core DSL](#saga-core-dsl)
 * * * [The Flow DSL](#saga-flow-dsl)
 * * * [Event Metadata](#saga-event-metadata)
 * * * [Effects Are Data](#saga-effects)
@@ -3630,11 +3630,10 @@ Here is the order-fulfillment process. `OrderPlaced` reserves payment and arms a
 {% capture kotlin %}
 val orderFulfillment: Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> =
     saga {
-        startsOn<OrderPlaced>(correlatedBy = { it.orderId }) { order ->
+        correlateAll { it.orderId }
+        startsOn<OrderPlaced> { order ->
             issue(ReservePayment(order.orderId, order.amount))
         }
-        correlate<PaymentReserved> { it.orderId }
-        correlate<PaymentFailed> { it.orderId }
         step("awaiting-payment") {
             on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
             on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
@@ -3647,10 +3646,9 @@ val orderFulfillment: Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> =
 {% capture java %}
 Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> orderFulfillment =
         FlowSaga.<OrderEvent, OrderCommand>builder()
-                .startsOn(OrderPlaced.class, OrderPlaced::orderId,
+                .correlateAll(OrderEvent::orderId)
+                .startsOn(OrderPlaced.class, null,
                         order -> List.of(new ReservePayment(order.orderId(), order.amount())))
-                .correlate(PaymentReserved.class, PaymentReserved::orderId)
-                .correlate(PaymentFailed.class, PaymentFailed::orderId)
                 .step("awaiting-payment", step -> step
                         .on(PaymentReserved.class, Continuation.end(),
                                 payment -> List.of(new ShipOrder(payment.orderId())))
@@ -3664,11 +3662,11 @@ Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> orderFulfillment =
 
 A saga is not a substitute for a [Dynamic Consistency Boundary](#dynamic-consistency-boundary). When two rules must hold atomically in one append, express both as a single `DcbCriteria` and let one decider decide against them together, which is cheaper and stronger. Reach for a saga only when the process is genuinely cross-boundary and time-involving. The "cancel if payment is not reserved within 30 minutes" rule has no single append at which both facts are known, because the payment may simply never arrive and the deciding write has to be triggered by the passage of time rather than by an event. That is the gap a saga fills, and the only one.
 
-There are two ways to author a saga, and both compile to the same `Saga<E, S, C>` descriptor, so the runner only ever runs one kind of thing. The flow DSL above is the sugar for the common case, a linear process moving through a few named steps. Underneath it is the machine core, an explicit per-event-type fold and reaction. Use the flow DSL when your process is a small sequence of steps, drop to the machine core when it is not.
+There are two ways to author a saga, and both compile to the same `Saga<E, S, C>` descriptor, so the runner only ever runs one kind of thing. The flow DSL above is the sugar for the common case, a linear process moving through a few named steps. Underneath it is the core DSL, an explicit per-event-type fold and reaction. Use the flow DSL when your process is a small sequence of steps, drop to the core DSL when it is not.
 
-### The Machine Core {#saga-machine-core}
+### The Core DSL {#saga-core-dsl}
 
-The machine core is `Saga.builder(initialState)` in Java and `saga(initialState) { }` in Kotlin. You register, per event type, an `evolve` that folds the event into state and a `react` that decides what to do now that the event has been applied. Timers get their own `evolveOnTimeout` and `reactOnTimeout`, keyed by name. `evolve` and `react` are kept separate on purpose. Rehydrating an instance from history calls only `evolve`, so replay can never re-issue a command.
+The core DSL is `Saga.builder(initialState)` in Java and `saga(initialState) { }` in Kotlin. You register, per event type, an `evolve` that folds the event into state and a `react` that decides what to do now that the event has been applied. Timers get their own `evolveOnTimeout` and `reactOnTimeout`, keyed by name. `evolve` and `react` are kept separate on purpose. Rehydrating an instance from history calls only `evolve`, so replay can never re-issue a command.
 
 Here is the same order-fulfillment process as the flow example above, written against an explicit `OrderSagaState`:
 
@@ -3722,7 +3720,7 @@ Saga<OrderEvent, OrderSagaState, OrderCommand> orderFulfillment =
 
 `correlateAll` (or a per-type `correlate`) says which instance an event belongs to, returned as a plain `String` id. `startsOn` names the event types that create a new instance. An event that correlates to no existing instance and is not a start event is skipped rather than starting one on the wrong event. `build()` fails loudly if any handled event type has no correlation rule, so "event arrived, no idea which instance" cannot happen at run time. `isTerminal` marks the states that end the process. A terminal instance ignores further input, and the runner cancels its outstanding timers.
 
-The flow DSL cannot express everything, on purpose. It has no dynamic N-of-M joins, no accumulators across steps, and no "this event is valid in every step" matching. A process that needs any of those drops to the machine core, where `evolve` and `react` can express them directly.
+The flow DSL cannot express everything, on purpose. It has no dynamic N-of-M joins, no accumulators across steps, and no "this event is valid in every step" matching. A process that needs any of those drops to the core DSL, where `evolve` and `react` can express them directly.
 
 ### The Flow DSL {#saga-flow-dsl}
 
@@ -3908,7 +3906,7 @@ CommandDispatcher<OrderCommand> dispatcher =
 
 The `SagaStateStore` persists each instance. `SagaStateStore.inMemory()` is for tests and single-node use, and `SpringMongoSagaStateStore` (in the blocking MongoDB starter) is the durable one. Unlike a read-model store it supports a compare-and-set save, because an event and a timer can touch the same instance concurrently, so the runner detects a lost update and retries instead of overwriting. Timers live in the same stored envelope as the state, not in an external scheduler. A timer poller inside the runner periodically reads instances with a due timer and re-enters them through the same pipeline a live event uses. That means no deadline or JobRunr infrastructure to run, at the cost of firing precision bounded by the poll interval, which does not matter at the minutes-to-days timescale sagas work on.
 
-Building a `SpringMongoSagaStateStore` by hand for a flow saga needs its four-argument constructor, with the application's `CloudEventConverter` passed alongside the state type. That converter is what lets the store serialize a `FlowState`'s retained events by their stable CloudEvent type rather than a Java class name. Passing `null`, or using the three-argument constructor, throws `IllegalArgumentException` rather than silently losing that package independence. A machine-core saga's state carries no such requirement, since it serializes with the application's own `MongoConverter`.
+Building a `SpringMongoSagaStateStore` by hand for a flow saga needs its four-argument constructor, with the application's `CloudEventConverter` passed alongside the state type. That converter is what lets the store serialize a `FlowState`'s retained events by their stable CloudEvent type rather than a Java class name. Passing `null`, or using the three-argument constructor, throws `IllegalArgumentException` rather than silently losing that package independence. A core saga's state carries no such requirement, since it serializes with the application's own `MongoConverter`.
 
 ### The `@Saga` Annotation {#the-saga-annotation}
 
@@ -3922,11 +3920,10 @@ class OrderFulfillmentSaga {
 
     @Saga(id = "order-fulfillment")
     fun orderFulfillment() = saga {
-        startsOn<OrderPlaced>(correlatedBy = { it.orderId }) { order ->
+        correlateAll { it.orderId }
+        startsOn<OrderPlaced> { order ->
             issue(ReservePayment(order.orderId, order.amount))
         }
-        correlate<PaymentReserved> { it.orderId }
-        correlate<PaymentFailed> { it.orderId }
         step("awaiting-payment") {
             on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
             on<PaymentFailed>(then = end) { failure -> issue(CancelOrder(failure.orderId, failure.reason)) }
@@ -3952,7 +3949,7 @@ class OrderFulfillmentSaga {
                 .react(OrderPlaced.class, (state, e) -> List.of(
                         SagaEffect.issue(new ReservePayment(e.orderId(), e.amount())),
                         SagaEffect.startTimeout("payment", Duration.ofMinutes(30))))
-                // ...the rest of the folds and reactions from the machine-core example above
+                // ...the rest of the folds and reactions from the core example above
                 .isTerminal(state -> state instanceof Completed || state instanceof Cancelled)
                 .build();
     }
@@ -3996,7 +3993,7 @@ Timer bookkeeping has no such gap, because `startTimeout` and `cancelTimeout` ar
 
 A live event and a firing timer do not fail the same way when a `SagaConcurrencyException` exhausts its compare-and-set retries. On the event path the exception propagates to the subscription model, which redelivers the event and retries the whole step; the event is never lost, but the subscription is one ordered channel shared by every instance the saga handles, so an instance that keeps failing blocks the events queued behind it (head-of-line blocking) until it succeeds or the subscription is intervened on. On the timer path the poller catches the exception per instance, logs it, and leaves the timer due for the next poll, so other instances keep progressing and a stuck timer never blocks the poller. Because commands are dispatched before the save and a lost compare-and-set retries the step, a single input can also re-dispatch its whole command list several times, up to the configured `maxCasAttempts`, so a receiver has to tolerate more than plain at-least-once multiplicity.
 
-A flow saga does not remember its whole history. The received log a join, guard, or timeout reaction reads through `ReceivedEvents` is bounded to a configurable window: the current step's own events plus a carry-over of `historyWindow` earlier events, `FlowSaga.Builder.historyWindow(int events)` in Java, defaulting to 100 (the Kotlin flow builder does not yet expose the knob and always uses the default). The initiating event is always retained regardless of the window, since `received.initiating<T>()` is a common lookup, but anything older than the window is dropped and not persisted. Raise the window for a guard or join that needs to count back further than the default 100 events, or lower it to trim what a long-running instance persists. `FlowState`'s bookkeeping fields (`stepEntryIndex`, `previousStep`, `lastAction`, `matchedBranchIndex`, `windowStart`) are internal to the executor and are not a wire-format compatibility guarantee, unlike the retained domain events themselves, which serialize as CloudEvents through the application's `CloudEventConverter`. That means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name, so a domain event can move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A machine-core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
+A flow saga does not remember its whole history. The received log a join, guard, or timeout reaction reads through `ReceivedEvents` is bounded to a configurable window: the current step's own events plus a carry-over of `historyWindow` earlier events, `FlowSaga.Builder.historyWindow(int events)` in Java, defaulting to 100 (the Kotlin flow builder does not yet expose the knob and always uses the default). The initiating event is always retained regardless of the window, since `received.initiating<T>()` is a common lookup, but anything older than the window is dropped and not persisted. Raise the window for a guard or join that needs to count back further than the default 100 events, or lower it to trim what a long-running instance persists. `FlowState`'s bookkeeping fields (`stepEntryIndex`, `previousStep`, `lastAction`, `matchedBranchIndex`, `windowStart`) are internal to the executor and are not a wire-format compatibility guarantee, unlike the retained domain events themselves, which serialize as CloudEvents through the application's `CloudEventConverter`. That means they persist by their stable `CloudEventTypeMapper` type, the same representation the event store uses, not by a Java class name, so a domain event can move to a different package without breaking in-flight saga state, exactly as it can for events in the event store. A core saga's state is your own model and serializes like the [snapshot](#snapshots) store.
 
 For the full design rationale, including the residual cross-node race a compare-and-set retry can produce and the deferred outbox that would make dispatch exactly-once, see [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md). The complete, runnable [order-fulfillment example](https://github.com/johanhaleby/occurrent/tree/occurrent-{{site.occurrentversion}}/example/saga/order-fulfillment) has both authoring surfaces wired through `SagaRunner` with both dispatcher styles.
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3957,7 +3957,7 @@ On the [Spring Boot starter](#spring-boot-starter) this is on by default. A `@Sa
 ```yaml
 occurrent:
   saga:
-    timer-poll-interval: 1s
+    timer-poll-interval: 15s   # the default, lower it only if you rely on short timeouts firing promptly
     competing-consumer:
       enabled: true   # set to false to let every instance poll (the uncoordinated behavior)
 ```

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -113,6 +113,7 @@ permalink: /documentation
 * * * [Delivery Contract](#saga-delivery-contract)
 * * * [Running Across Multiple Instances](#saga-multi-instance)
 * * * [Side Effects and Compensation](#saga-side-effects)
+* * * [Observing Saga Instances](#observing-saga-instances)
 * [Spring Boot Starter](#spring-boot-starter)
 * * [Reactive Spring Boot Starter](#reactive-spring-boot-starter)
 * * [Annotations](#spring-boot-annotations)
@@ -4058,6 +4059,76 @@ timeout(after = Duration.ofMinutes(30), then = end) { received ->
 Both branches issue the same forward-moving `CancelOrder` compensation for the `ReservePayment` issued when the step started, whichever failure mode gets there first.
 
 The one thing to watch is idempotency, and it follows directly from the [delivery contract](#saga-delivery-contract). Command dispatch is at-least-once, so a compensating or external command can arrive twice. An `ApplicationService`-backed target handles that for free, because it re-folds the stream and the target's own invariants reject the duplicate. A raw third-party call does not. When a command triggers a non-idempotent external effect such as an email, a payment capture, or a partner request, give it a stable id derived from the saga and the triggering event, and dedupe at that boundary. The deferred document-local outbox described in [ADR 0063](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0063-saga-dsl.md) would make dispatch exactly-once and remove this caveat, but it is not built yet.
+
+### Observing Saga Instances {#observing-saga-instances}
+
+A saga runs for as long as its process does, so sooner or later you need to ask operational questions about one. Is this instance still running, which step is it waiting in, and which instances have stopped moving? `SagaInstance` answers those and nothing else:
+
+{% capture kotlin %}
+val instances = subscription.instances()
+
+instances.find(orderId).ifPresent { instance ->
+    println("${instance.sagaId()} is ${instance.status()} in step ${instance.currentStep()}")
+}
+
+// active instances that have not moved for an hour, stalest first
+val stalled = instances.findByStatus(SagaStatus.ACTIVE, Instant.now().minus(Duration.ofHours(1)), 50)
+{% endcapture %}
+{% capture java %}
+SagaInstances instances = subscription.instances();
+
+instances.find(orderId).ifPresent(instance ->
+        System.out.println(instance.sagaId() + " is " + instance.status() + " in step " + instance.currentStep()));
+
+// active instances that have not moved for an hour, stalest first
+List<SagaInstance> stalled = instances.findByStatus(SagaStatus.ACTIVE, Instant.now().minus(Duration.ofHours(1)), 50);
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+A `SagaInstance` carries the id, the `SagaStatus` (`ACTIVE` or `COMPLETED`), the created, updated, and completed timestamps, when the next pending timer is due, and which step a flow saga is waiting in. `currentStep()` is `null` for a core saga, which names its states in your own state type rather than in a step the executor knows about.
+
+It leaves out the saga's own state and the executor's delivery bookkeeping on purpose. A read model shaped for querying belongs in the [Projection DSL](#views), and folding over a saga's private state from outside ties your code to how that process happens to be written.
+
+There is no way to write through this. Nothing here starts, advances, completes, or deletes an instance, because the executor owns those transitions and a compare-and-set save from outside would race the subscription and the timer poller. Retention tooling that really has to remove an instance calls `SagaStateStore.delete(...)`.
+
+`findByStatus` returns the instances in a status whose `updatedAt` falls strictly before the instant you pass, least recently updated first, at most `limit` of them. Pass `Instant.now()` to list everything in a status, or `Instant.now().minus(threshold)` to find the ones that have gone quiet. Stalest-first is what a stuck-instance check wants, because the worst offenders arrive first rather than last. `limit` bounds the result, it does not page it: timestamps persist at millisecond precision, so instances saved in the same millisecond tie, and a timestamp cursor would drop most of a tie group.
+
+Enumeration is an optional store capability. A store implements `SagaStateStoreQueries` to support it, both shipped stores do, and `findByStatus` throws an `UnsupportedOperationException` on a store that does not. `find(sagaId)` works on any store, so a store you wrote yourself to run sagas never has to answer an ordered query it does not need.
+
+On the Spring stack the `@Saga` registrar publishes each saga's `SagaInstances` under a registry keyed by saga id:
+
+{% capture kotlin %}
+@Service
+class SagaDashboard(private val registry: SagaInstancesRegistry) {
+
+    fun stalled(sagaId: String, threshold: Duration): List<SagaInstance> =
+        registry.get(sagaId).findByStatus(SagaStatus.ACTIVE, Instant.now().minus(threshold), 100)
+
+    fun sagaIds(): Set<String> = registry.sagaIds()
+}
+{% endcapture %}
+{% capture java %}
+@Service
+class SagaDashboard {
+
+    private final SagaInstancesRegistry registry;
+
+    SagaDashboard(SagaInstancesRegistry registry) {
+        this.registry = registry;
+    }
+
+    List<SagaInstance> stalled(String sagaId, Duration threshold) {
+        return registry.get(sagaId).findByStatus(SagaStatus.ACTIVE, Instant.now().minus(threshold), 100);
+    }
+}
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+`get(id)` throws and names every id that is registered, which is what you want when the id is a constant in your own code. `find(id)` returns an `Optional` for an id that came from a request or a configuration value. `sagaIds()` lists them so a dashboard does not hardcode ids. Each saga is also published under the bean name `sagaInstances-<id>`, reachable with `getBean` or a `@Qualifier` if you prefer to inject one saga's view directly.
+
+One timing constraint comes with the annotation path. A `@Saga` factory can only run once the beans it collaborates with are wired, which is after the context has refreshed, so the registry holds nothing until that scan has run. Inject it and read it when a request arrives, never from another bean's constructor.
+
+Enumerating instances does not read saga state at all. The MongoDB store keeps `currentStep` in its own document field, the same way it already keeps the earliest pending timer, and projects the rest away, so listing flow-saga instances never decodes their received events. It indexes status together with `updatedAt` to serve the query. Rationale in [ADR 0070](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0070-saga-instance-observation.md).
 
 ## Reactive Spring Boot Starter
 


### PR DESCRIPTION
Documents the Saga DSL (ADR 0063) for the website, held until 0.31.0 ships.

Covers both authoring surfaces (the machine core and the flow DSL), effects as data, correlation, timeouts, running a saga, the `@Saga` annotation, the delivery contract, and side effects and compensation, with worked Java and Kotlin examples grounded in the `order-fulfillment` example.

It also states the flow-saga history-retention contract as it now stands in the code: the received-event log is bounded to a configurable window (`FlowSaga.Builder.historyWindow(int)`, default 100), joins, guards, and timeout reactions see the retained window, and the initiating event is always kept. The saga guards are documented too (the `startsOn`/`correlate` double-registration check and the `CloudEventConverter` requirement for a hand-built `SpringMongoSagaStateStore`).

Hold for next release.
