### PR TITLE
Add 0.31.0 'Added in' version labels and document the convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository guide
+
+This is [occurrent.org](https://occurrent.org), the documentation site for [Occurrent](https://github.com/johanhaleby/occurrent). It is a Jekyll site. The main documentation page is `pages/docs/docs.md`, rendered at `/documentation`, and release announcements live under `_posts/news/`.
+
+## "Added in vX.Y.Z" version labels
+
+The documentation marks when a feature first shipped with a small "Added in vX.Y.Z" badge next to its heading (the Query DSL heading is an example). These labels come from the `addedTags` map in `js/_partials/main.js`, and only run on the `/documentation` page.
+
+Each entry maps a section's HTML id to the version that introduced it:
+
+```js
+"saga-dsl" : "0.31.0",
+```
+
+The id is the one kramdown generates from the heading text, lowercased with spaces turned into hyphens, so `## Saga DSL` becomes `saga-dsl`. When a heading sets an explicit `{#anchor}`, use that anchor instead. A label whose id matches no element on the page is skipped, so an entry can be added before its section merges without breaking the page.
+
+When you document a feature that ships in a release, add its id and version here. Do the same when you rewrite an existing section to describe newly added first-class support, as the `## Snapshots` section was for 0.31.0.
+
+## Prose voice
+
+Human-facing prose (documentation, news posts, PR descriptions) follows Johan's writing style: direct, concrete, no corporate filler. Do not use em-dashes, en-dashes, or semicolons in prose, recast with commas, periods, or parentheses. Johan drives this with the `johan-writing` skill.
+
+## Release workflow
+
+Documentation for an unreleased Occurrent feature lives on its own branch, one branch and pull request per feature, and is held until the matching library release ships. `main` tracks the released site, so do not push feature documentation straight to `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for repository conventions and agent guidance.

--- a/js/_partials/main.js
+++ b/js/_partials/main.js
@@ -75,7 +75,11 @@ if (document.location.pathname.includes("/documentation")) {
         "query-dsl" : "0.14.0",
         "spring-boot-starter" : "0.14.0",
         "deadlines" : "0.15.0",
-        "spring-boot-annotations" : "0.18.0"
+        "spring-boot-annotations" : "0.18.0",
+        "saga-dsl" : "0.31.0",
+        "projection-dsl" : "0.31.0",
+        "snapshots" : "0.31.0",
+        "synchronous-subscriptions" : "0.31.0"
         // "validator-nullability": "3.1.0",
         // "shared-state": "3.2.0",
         // "vue-directory-location": "3.5.0",


### PR DESCRIPTION
Adds the "Added in v0.31.0" heading labels for the new sections this release, the same badge the Query DSL heading already carries. Four entries go into the `addedTags` map in `js/_partials/main.js`: `saga-dsl`, `projection-dsl`, `snapshots` (rewritten this release for first-class snapshot support), and `synchronous-subscriptions`.

It also records the convention in a new `AGENTS.md` (with a `CLAUDE.md` that just points at it), covering how the labels work, the prose voice, and the hold-for-release branch workflow.

I left out Command Dispatch, its documentation is still an uncommitted work-in-progress on `docs/command-dispatch` rather than on the branch, and the Push Subscription docs, which are a subsection rather than a top-level feature heading. Both are easy to add once their sections land.

The label script skips any id it does not find on the page, so these entries are safe on `main` before the feature sections merge, and the badges light up as each held branch lands.
