### PR TITLE
Document command dispatch (hold for next release)

### DIFF
--- a/_includes/macros/command-dispatch/annotation/maven.md
+++ b/_includes/macros/command-dispatch/annotation/maven.md
@@ -1,0 +1,32 @@
+{% capture maven %}
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-command-dispatch-annotation</artifactId>
+    <version>{{site.occurrentversion}}</version>
+</dependency>
+{% endcapture %}
+
+{% capture gradle %}
+compile 'org.occurrent:occurrent-command-dispatch-annotation:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture sbt %}
+libraryDependencies += "org.occurrent" % "occurrent-command-dispatch-annotation" % "{{site.occurrentversion}}"
+{% endcapture %}
+
+{% capture grape %}
+@Grab(group='org.occurrent', module='occurrent-command-dispatch-annotation', version='{{site.occurrentversion}}') 
+{% endcapture %}
+
+{% capture leiningen %}
+[org.occurrent/occurrent-command-dispatch-annotation "{{site.occurrentversion}}"]
+{% endcapture %}
+
+{% capture buildr %}
+'org.occurrent:occurrent-command-dispatch-annotation:jar:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture ivy %}
+<dependency org="org.occurrent" name="occurrent-command-dispatch-annotation" rev="{{site.occurrentversion}}" />
+{% endcapture %}
+{% include macros/mavenSnippet.html maven=maven gradle=gradle sbt=sbt grape=grape leiningen=leiningen buildr=buildr ivy=ivy%}

--- a/_includes/macros/command-dispatch/core/maven.md
+++ b/_includes/macros/command-dispatch/core/maven.md
@@ -1,0 +1,32 @@
+{% capture maven %}
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-command-dispatch</artifactId>
+    <version>{{site.occurrentversion}}</version>
+</dependency>
+{% endcapture %}
+
+{% capture gradle %}
+compile 'org.occurrent:occurrent-command-dispatch:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture sbt %}
+libraryDependencies += "org.occurrent" % "occurrent-command-dispatch" % "{{site.occurrentversion}}"
+{% endcapture %}
+
+{% capture grape %}
+@Grab(group='org.occurrent', module='occurrent-command-dispatch', version='{{site.occurrentversion}}') 
+{% endcapture %}
+
+{% capture leiningen %}
+[org.occurrent/occurrent-command-dispatch "{{site.occurrentversion}}"]
+{% endcapture %}
+
+{% capture buildr %}
+'org.occurrent:occurrent-command-dispatch:jar:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture ivy %}
+<dependency org="org.occurrent" name="occurrent-command-dispatch" rev="{{site.occurrentversion}}" />
+{% endcapture %}
+{% include macros/mavenSnippet.html maven=maven gradle=gradle sbt=sbt grape=grape leiningen=leiningen buildr=buildr ivy=ivy%}

--- a/_includes/macros/command-dispatch/dcb/maven.md
+++ b/_includes/macros/command-dispatch/dcb/maven.md
@@ -1,0 +1,32 @@
+{% capture maven %}
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-command-dispatch-dcb</artifactId>
+    <version>{{site.occurrentversion}}</version>
+</dependency>
+{% endcapture %}
+
+{% capture gradle %}
+compile 'org.occurrent:occurrent-command-dispatch-dcb:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture sbt %}
+libraryDependencies += "org.occurrent" % "occurrent-command-dispatch-dcb" % "{{site.occurrentversion}}"
+{% endcapture %}
+
+{% capture grape %}
+@Grab(group='org.occurrent', module='occurrent-command-dispatch-dcb', version='{{site.occurrentversion}}') 
+{% endcapture %}
+
+{% capture leiningen %}
+[org.occurrent/occurrent-command-dispatch-dcb "{{site.occurrentversion}}"]
+{% endcapture %}
+
+{% capture buildr %}
+'org.occurrent:occurrent-command-dispatch-dcb:jar:{{site.occurrentversion}}'
+{% endcapture %}
+
+{% capture ivy %}
+<dependency org="org.occurrent" name="occurrent-command-dispatch-dcb" rev="{{site.occurrentversion}}" />
+{% endcapture %}
+{% include macros/mavenSnippet.html maven=maven gradle=gradle sbt=sbt grape=grape leiningen=leiningen buildr=buildr ivy=ivy%}

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -39,6 +39,8 @@ permalink: /documentation
 * * * [Side-Effects](#application-service-side-effects)
 * * * [Transactional Side-Effects](#application-service-transactional-side-effects)
 * * * [Kotlin](#application-service-kotlin-extensions)
+* * [Command Dispatch](#command-dispatch)
+* * * [Deriving the Stream Id From Annotations](#deriving-the-stream-id-from-annotations)
 * * [Sagas](#sagas)
 * * [Policy](#policy)
 * * * [Asynchronous](#asynchronous-policy)
@@ -1634,6 +1636,46 @@ applicationService.execute(
 ```
 
 For synchronous side effects, prefer `sideEffect(...)` or `options().sideEffect(...)` rather than the older policy-style helpers.
+
+## Command Dispatch
+
+A saga or a policy needs to issue commands without knowing how those commands get turned into events. `CommandDispatcher<C>` is the interface for that, with one method, `void dispatch(C command)`. Delivery is at-least-once, so whatever `dispatch` calls into must be safe to run twice on the same command. Running it twice should never append the same events a second time.
+
+{% include macros/command-dispatch/core/maven.md %}
+
+`ApplicationService` is the write engine underneath. It takes a stream id and a decider, reads the stream, decides what to append, and appends it. A `CommandDispatcher` is what the saga calls instead of the `ApplicationService` directly. It resolves which stream the command targets, then hands the command to the `ApplicationService` (or an equivalent write path) that does the actual read, decide, and append. The saga only knows the command, not the stream id or the decider behind it.
+
+To resolve the target stream, a `CommandDispatcher` implementation needs a `StreamIdResolver<C>`, another single-method interface, `String streamId(C command)`. Write one by hand when the stream id has to be computed from the command, or derive it automatically with `@TargetStreamId`.
+
+### Deriving the Stream Id From Annotations
+
+Put `@TargetStreamId` on the field, record component, or getter that already holds the command's target stream id, and `AnnotationStreamIdResolver` reads it with reflection, so you don't have to write a `StreamIdResolver` by hand.
+
+{% capture java %}
+public record EnrollStudent(@TargetStreamId String courseId, String studentId) {
+}
+
+StreamIdResolver<EnrollStudent> streamIdResolver = new AnnotationStreamIdResolver<>();
+// streamIdResolver.streamId(command) returns command.courseId()
+{% endcapture %}
+{% capture kotlin %}
+data class EnrollStudent(
+    @get:TargetStreamId val courseId: String,
+    val studentId: String
+)
+
+val streamIdResolver: StreamIdResolver<EnrollStudent> = AnnotationStreamIdResolver()
+// streamIdResolver.streamId(command) returns command.courseId
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+Only one field, record component, or getter per command class can carry `@TargetStreamId`. `AnnotationStreamIdResolver` also accepts a different annotation of your own, for a command that already carries one you'd rather reuse.
+
+{% include macros/command-dispatch/annotation/maven.md %}
+
+This is the single-stream match to [deriving DCB tags from annotations](#deriving-tags-from-annotations). `@DcbTag` marks the fields that become the tags for a DCB boundary spanning several streams. `@TargetStreamId` marks the one field that already is the id of a single stream.
+
+The Spring Boot starter registers a default `StreamIdResolver` bean backed by `AnnotationStreamIdResolver`, scanning your commands for `@TargetStreamId`. Define your own `StreamIdResolver` bean when a command's stream id needs computing rather than reading off one field, and the starter uses that bean instead.
 
 ## Sagas
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -40,6 +40,7 @@ permalink: /documentation
 * * * [Transactional Side-Effects](#application-service-transactional-side-effects)
 * * * [Kotlin](#application-service-kotlin-extensions)
 * * [Command Dispatch](#command-dispatch)
+* * * [Convenience Factories](#convenience-factories)
 * * * [Deriving the Stream Id From Annotations](#deriving-the-stream-id-from-annotations)
 * * [Sagas](#sagas)
 * * [Policy](#policy)
@@ -1646,6 +1647,63 @@ A saga or a policy needs to issue commands without knowing how those commands ge
 `ApplicationService` is the write engine underneath. It takes a stream id and a decider, reads the stream, decides what to append, and appends it. A `CommandDispatcher` is what the saga calls instead of the `ApplicationService` directly. It resolves which stream the command targets, then hands the command to the `ApplicationService` (or an equivalent write path) that does the actual read, decide, and append. The saga only knows the command, not the stream id or the decider behind it.
 
 To resolve the target stream, a `CommandDispatcher` implementation needs a `StreamIdResolver<C>`, another single-method interface, `String streamId(C command)`. Write one by hand when the stream id has to be computed from the command, or derive it automatically with `@TargetStreamId`.
+
+### Convenience Factories
+
+Wiring a `CommandDispatcher` by hand means picking an `ApplicationService`, a `Decider`, and (for the stream case) a `StreamIdResolver`, and gluing them together yourself. `CommandDispatchers.decider(...)` and `DcbCommandDispatchers.decider(...)` do that gluing for you, one factory per style of decider.
+
+For a stream-keyed decider, `org.occurrent.command.CommandDispatchers.decider(deciderApplicationService, decider, streamIdResolver)` builds a `CommandDispatcher<C>` that resolves the stream id, then executes the decider through the application service. It lives in `occurrent-command-dispatch`, the same module as `CommandDispatcher` itself, but using it also pulls in `occurrent-decider`, a light, optional dependency you'd otherwise add yourself.
+
+{% capture java %}
+public record PlaceOrder(@TargetStreamId String orderId, String productId, int quantity) {
+}
+
+Decider<PlaceOrder, OrderState, OrderEvent> placeOrderDecider = ...;
+DeciderApplicationService<OrderEvent> applicationService = ...;
+StreamIdResolver<PlaceOrder> streamIdResolver = new AnnotationStreamIdResolver<>();
+
+CommandDispatcher<PlaceOrder> dispatcher = CommandDispatchers.decider(applicationService, placeOrderDecider, streamIdResolver);
+
+dispatcher.dispatch(new PlaceOrder(orderId, productId, quantity));
+{% endcapture %}
+{% capture kotlin %}
+data class PlaceOrder(
+    @get:TargetStreamId val orderId: String,
+    val productId: String,
+    val quantity: Int
+)
+
+val placeOrderDecider: Decider<PlaceOrder, OrderState, OrderEvent> = ...
+val applicationService: DeciderApplicationService<OrderEvent> = ...
+val streamIdResolver: StreamIdResolver<PlaceOrder> = AnnotationStreamIdResolver()
+
+val dispatcher: CommandDispatcher<PlaceOrder> = CommandDispatchers.decider(applicationService, placeOrderDecider, streamIdResolver)
+
+dispatcher.dispatch(PlaceOrder(orderId, productId, quantity))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+For a [`DcbDecider`](#coupling-a-decider-to-a-boundary), `org.occurrent.command.dcb.DcbCommandDispatchers.decider(dcbDeciderApplicationService, dcbDecider)` takes only those two arguments. A `DcbDecider` already carries its own `DcbCriteria` and `TagGenerator`, so there's no stream id to resolve. This factory lives in its own module, `occurrent-command-dispatch-dcb`, kept separate from `occurrent-command-dispatch` so that dispatching commands to plain, stream-keyed deciders doesn't drag in the DCB and CloudEvent stack.
+
+{% include macros/command-dispatch/dcb/maven.md %}
+
+{% capture java %}
+DcbDecider<EnrollStudent, EnrollmentState, DomainEvent> enrollmentDecider = ...;
+DcbDeciderApplicationService<DomainEvent> applicationService = ...;
+
+CommandDispatcher<EnrollStudent> dispatcher = DcbCommandDispatchers.decider(applicationService, enrollmentDecider);
+
+dispatcher.dispatch(new EnrollStudent(courseId, studentId));
+{% endcapture %}
+{% capture kotlin %}
+val enrollmentDcbDecider: DcbDecider<EnrollStudent, EnrollmentState, DomainEvent> = ...
+val applicationService: DcbDeciderApplicationService<DomainEvent> = ...
+
+val dispatcher: CommandDispatcher<EnrollStudent> = DcbCommandDispatchers.decider(applicationService, enrollmentDcbDecider)
+
+dispatcher.dispatch(EnrollStudent(courseId, studentId))
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 ### Deriving the Stream Id From Annotations
 


### PR DESCRIPTION
Documents the command-dispatch modules for 0.31.0: `CommandDispatcher` and `StreamIdResolver`, deriving the target stream id from a `@TargetStreamId` member with `AnnotationStreamIdResolver`, and the `CommandDispatchers.decider(...)` and `DcbCommandDispatchers.decider(...)` convenience factories with the Maven coordinates for `occurrent-command-dispatch-dcb`.

Command dispatch has not been released yet, so hold this until the release ships.
