### PR TITLE
Document the published MongoDB flush, and why it deletes rather than drops

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -5803,17 +5803,27 @@ void order_projection_is_updated_when_an_order_is_placed() {
 
 Stopping in `afterEach` matters as much as in `beforeEach`. Spring caches the test context across test classes, so a subscription that one class resumed is still running when the next class starts.
 
-If you also flush the database between tests, stop the subscriptions first, and pin the order with `@Order` rather than relying on the order of the fields:
+If you also empty the database between tests, hand that to the same extension rather than registering a second one. It runs after every subscription is stopped and before any is resumed, which is the only order that works, and `clearingCheckpoints` takes care of the checkpoints:
 
 ```java
 @RegisterExtension
-@Order(1)
-OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel);
-
-@RegisterExtension
-@Order(2)
-FlushDatabaseExtension flush = new FlushDatabaseExtension(mongoTemplate);
+OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel)
+        .clearingStateWith(OccurrentMongoFlush.everyCollectionIn(mongoTemplate.getDb()))
+        .clearingCheckpoints(checkpointStorage);
 ```
+
+`OccurrentMongoFlush` comes from `occurrent-testing-mongodb`:
+
+```xml
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-testing-mongodb</artifactId>
+    <version>{{site.occurrentversion}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+`clearingStateWith` takes any `Runnable`, so a store other than MongoDB fits the same shape.
 
 ### Naming several subscriptions, or all of them {#testing-subscription-starting-several}
 
@@ -5872,9 +5882,17 @@ The extension bean is all `@EnableOccurrentTesting` adds. Your event store and s
 
 Your application registers its subscriptions at startup through its annotations, so a test never registers them itself. Outside Spring, register them once in `@BeforeAll`. Doing it in `@BeforeEach` fails on the second test with `Subscription <id> is already defined`, and would not work anyway, because JUnit runs an extension's `beforeEach` before any `@BeforeEach` method, so a subscription created there is never stopped.
 
-While flushing, delete the documents instead of dropping the collections or the database. Dropping them invalidates a live MongoDB change stream, and the subscriptions you resume afterwards then receive nothing.
+`everyCollectionIn` deletes the documents rather than dropping anything, which matters for two reasons.
 
-Flush the checkpoint collection along with the events, `subscriptions` unless you changed `occurrent.subscription.collection`. Resuming a subscription continues from its stored checkpoint, so a subscription left behind by an earlier test picks up whatever that test wrote while it was stopped, and the second test then sees events it never wrote. Clearing the events alone does not prevent this, because the checkpoint is what decides where the resume starts.
+Dropping a collection or a database invalidates a live MongoDB change stream, and the subscriptions you resume afterwards then receive nothing. Stopping the model first does not save you, because it resumes from a position that points into a collection which no longer exists.
+
+The quieter reason is that your event store creates its unique indexes when it is constructed, so dropping removes them and only a new store brings them back. Spring caches the test context, so nothing constructs one again, and your optimistic-concurrency and duplicate-detection tests keep passing for the rest of the run with no index behind them. That failure never announces itself, which makes it the worse of the two.
+
+It names no collections, on purpose. Occurrent writes to more of them than you are likely to remember: the events, a stream position collection, a DCB checkpoint collection, the checkpoint collection below, and a competing consumer lock collection. A list you maintain by hand stops covering one the day you switch a feature on. Use `collectionsIn(database, ..)` only when the database holds something a test has to keep, and `except(..)` to spare one collection from the sweep.
+
+For the one case deleting cannot serve, a test asserting that a collection or an index does *not* exist, there is `droppingTheDatabaseIn(database)`. Nothing else should reach for it.
+
+The checkpoints have to go too, which is what `clearingCheckpoints` is for. Resuming a subscription continues from its stored checkpoint, so a subscription left behind by an earlier test picks up whatever that test wrote while it was stopped, and the second test then sees events it never wrote. Clearing the events alone does not prevent this, because the checkpoint is what decides where the resume starts. It works through `CheckpointStorage` rather than a collection name, so it is right whether your checkpoints live beside the events or in Redis.
 
 The in-memory subscription model does not have this problem. Events written while a subscription is stopped are dropped rather than queued, so there is nothing to catch up on when a later test starts it again.
 


### PR DESCRIPTION
Held for release, like the others, since `occurrent-testing-mongodb` ships in 0.32.0 (occurrent#520, ADR 95).

**Stacked on #22**, which is where the testing chapter first names `occurrent-testing-junit-jupiter`. This edits the same section, so basing it on `main` would have meant writing against text that is not there yet and conflicting with #22 at release time. Merge #22 first.

The chapter already told the reader the two rules, delete documents rather than dropping, and flush the checkpoint collection, and then left them to implement both with a hand-rolled extension whose order they had to pin with `@Order`. Both are library behaviour now, composed into the extension that already stops the subscriptions, so nothing has to be ordered:

```java
OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel)
        .clearingStateWith(OccurrentMongoFlush.everyCollectionIn(mongoTemplate.getDb()))
        .clearingCheckpoints(checkpointStorage);
```

Three things are new rather than reworded.

`everyCollectionIn` names no collections, and the docs now say why that is the point rather than a convenience: Occurrent writes to the events, a stream position collection, a DCB checkpoint collection, the checkpoint collection, and a competing consumer lock collection, so a list you keep by hand stops covering one the day you switch a feature on.

The second reason to delete rather than drop is written down for the first time. Dropping destroys the event store's unique indexes, which are created when the store is constructed, so a cached Spring test context never brings them back and optimistic-concurrency and duplicate-detection tests keep passing with no index behind them. That one never announces itself, which makes it worse than the change stream going quiet.

`clearingCheckpoints` works through `CheckpointStorage` rather than a collection name, so the guidance is now right for checkpoints kept in Redis, which the old paragraph naming the `subscriptions` collection was not.

`droppingTheDatabaseIn` is mentioned once, for the case deleting cannot serve, a test asserting a collection or an index does not exist.
