### PR TITLE
Document a saga fed from a broker (hold until 0.32.0)

### DIFF
--- a/js/_partials/main.js
+++ b/js/_partials/main.js
@@ -82,7 +82,8 @@ if (document.location.pathname.includes("/documentation")) {
         "synchronous-subscriptions" : "0.31.0",
         "dcb-read-options" : "0.31.0",
         "change-stream-tuning" : "0.31.0",
-        "retry-and-transactions" : "0.31.0"
+        "retry-and-transactions" : "0.31.0",
+        "saga-push-source" : "0.32.0"
         // "validator-nullability": "3.1.0",
         // "shared-state": "3.2.0",
         // "vue-directory-location": "3.5.0",

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -2906,7 +2906,7 @@ Live-resume stays the broker's job. The model persists no live position watermar
 
 Declaratively, a `@Projection` binds to a push source with `source = Source.PUSH` and `subscriptionModel` or `subscriptionModelName` to pick the `PushSubscriptionModel` bean. The starter then wraps it in the catch-up for you, on both the blocking and reactor stacks. Push source is rejected together with `mode = Mode.SYNCHRONOUS`, the catch-up start knobs, and a `DcbProjection`.
 
-Add `catchup = Catchup.NONE` when the feed carries events that are not in this application's event store, which is the case when another application writes them. The wrapper is skipped entirely and the bare `PushSubscriptionModel` is used instead, so no `PositionOrderedReader` or `CheckpointStorage` bean is needed. Left at the default `Catchup.FROM_EVENT_STORE`, a missing one of those beans now fails naming `catchup = NONE` as the fix, rather than a bare missing-bean error. `startAt`, `startAtGlobalPosition` and `resumeBehavior` stay rejected either way. `startupMode` only applies under the default, since `NONE` has no replay for `startupMode = BACKGROUND` to move off the startup path.
+Add `catchup = Catchup.NONE` when the feed carries events that are not in this application's event store, which is the case when another application writes them. The wrapper is skipped entirely and the bare `PushSubscriptionModel` is used instead, so no `PositionOrderedReader` or `CheckpointStorage` bean is needed. Left at the default `Catchup.FROM_EVENT_STORE`, a missing one of those beans now fails naming `catchup = Catchup.NONE` as the fix, rather than a bare missing-bean error. `startAt`, `startAtGlobalPosition` and `resumeBehavior` stay rejected either way. `startupMode` only applies under the default, since `Catchup.NONE` has no replay for `startupMode = BACKGROUND` to move off the startup path.
 
 ##### Feeding domain events instead of CloudEvents
 
@@ -5065,8 +5065,12 @@ class OrderFulfillmentSaga {
     }
 }
 
-@Bean("orderEvents")
-fun orderEvents() = PushSubscriptionModel()
+@Configuration
+class OrderEventsConfig {
+
+    @Bean("orderEvents")
+    fun orderEvents() = PushSubscriptionModel()
+}
 {% endcapture %}
 {% capture java %}
 import org.occurrent.annotation.Saga;
@@ -5088,9 +5092,13 @@ class OrderFulfillmentSaga {
     }
 }
 
-@Bean("orderEvents")
-PushSubscriptionModel orderEvents() {
-    return new PushSubscriptionModel();
+@Configuration
+class OrderEventsConfig {
+
+    @Bean("orderEvents")
+    PushSubscriptionModel orderEvents() {
+        return new PushSubscriptionModel();
+    }
 }
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
@@ -5123,7 +5131,7 @@ A saga that has run before picks up where it left off either way, because its pe
 
 ##### Forward the Occurrent extensions
 
-A saga recognises a redelivered event by its `streamid` together with its `streamversion`, or by its `position`. A broker delivers at least once, so an event that arrives without any of those is reacted to a second time and its commands are issued again. Occurrent's own stored events always carry them, so this is about what your listener forwards, not about the event store. The saga logs a warning the first time it sees an event without them, naming the saga so you can find it.
+A saga recognizes a redelivered event by its `streamid` together with its `streamversion`, or by its `position`. A broker delivers at least once, so an event that arrives without any of those is reacted to a second time and its commands are issued again. Occurrent's own stored events always carry them, so this is about what your listener forwards, not about the event store. The saga logs a warning the first time it sees an event without them, naming the saga so you can find it.
 
 This is also why a `@Saga` accepts only a `PushSubscriptionModel` and not a [`DomainEventFeed`](#feeding-domain-events-instead-of-cloudevents), which a `@Projection` does accept. A domain event feed carries no stream metadata, so a saga bound to one would lose its redelivery protection without saying anything.
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -2906,6 +2906,8 @@ Live-resume stays the broker's job. The model persists no live position watermar
 
 Declaratively, a `@Projection` binds to a push source with `source = Source.PUSH` and `subscriptionModel` or `subscriptionModelName` to pick the `PushSubscriptionModel` bean. The starter then wraps it in the catch-up for you, on both the blocking and reactor stacks. Push source is rejected together with `mode = Mode.SYNCHRONOUS`, the catch-up start knobs, and a `DcbProjection`.
 
+Add `catchup = Catchup.NONE` when the feed carries events that are not in this application's event store, which is the case when another application writes them. The wrapper is skipped entirely and the bare `PushSubscriptionModel` is used instead, so no `PositionOrderedReader` or `CheckpointStorage` bean is needed. Left at the default `Catchup.FROM_EVENT_STORE`, a missing one of those beans now fails naming `catchup = NONE` as the fix, rather than a bare missing-bean error. `startAt`, `startAtGlobalPosition` and `resumeBehavior` stay rejected either way. `startupMode` only applies under the default, since `NONE` has no replay for `startupMode = BACKGROUND` to move off the startup path.
+
 ##### Feeding domain events instead of CloudEvents
 
 If your listener already hands you domain events (for example a broker message converter deserializes them for you), pushing them through the CloudEvent model means `domainEvent` to `CloudEvent` and back, a full serialize and deserialize per event. Feed the projection in domain space instead and the live path does no conversion at all.
@@ -2932,7 +2934,15 @@ CatchupProjectionFeed<OrderEvent> feed = CatchupProjectionFeed.create(
 feed.catchUp();
 ```
 
-Declaratively, `DomainEventFeed<E>` is a feed you declare as a bean (carrying the `eventId` function) and feed from your listener, and `@Projection(source = Source.PUSH, subscriptionModelName = "ordersFeed")` binds a projection to it. Push source is one attribute: the starter looks at the referenced feed bean and, seeing a `DomainEventFeed` rather than a `PushSubscriptionModel`, folds domain events directly. It registers the projection on the feed and runs its catch-up. One feed can drive several projections. On the reactor stack the projection's store must be a `ViewStateRepository`. The `occurrent.subscription.catchup-then-live.*` properties do not reach this feed, because you declare the bean yourself, so tune its catch-up by passing `CatchupThenLiveOptions` to the `DomainEventFeed` constructor.
+When the feed's events are not in the local event store, there is nothing for `catchUp()` to read, and `register(...)` still buffers every `accept(...)` until told to stop, so events pile up until the buffer's cap throws. Call `goLive()` instead, on both `CatchupProjectionFeed` and `DomainEventFeed` (`goLive(id)` on the feed, naming the projection the same way `catchUp(id)` does):
+
+```java
+feed.goLive();
+```
+
+It skips the replay and starts delivering the buffered and future live events directly, writing no completion marker, so a later real `catchUp()` on the same feed still replays the full history rather than treating it as already done.
+
+Declaratively, `DomainEventFeed<E>` is a feed you declare as a bean (carrying the `eventId` function) and feed from your listener, and `@Projection(source = Source.PUSH, subscriptionModelName = "ordersFeed")` binds a projection to it. Push source is one attribute: the starter looks at the referenced feed bean and, seeing a `DomainEventFeed` rather than a `PushSubscriptionModel`, folds domain events directly. It registers the projection on the feed and runs its catch-up. One feed can drive several projections. On the reactor stack the projection's store must be a `ViewStateRepository`. The `occurrent.subscription.catchup-then-live.*` properties do not reach this feed, because you declare the bean yourself, so tune its catch-up by passing `CatchupThenLiveOptions` to the `DomainEventFeed` constructor. `catchup = Catchup.NONE` calls `goLive(id)` here instead of running the catch-up, for a feed whose events are not in this application's event store.
 
 A replayed event always has a real `CloudEvent` behind it, so the catch-up always folds with real metadata. A live event does not, so metadata on the live path is whatever the source supplies. Both `CatchupProjectionFeed` and `DomainEventFeed` accept it as a second argument, `feed.accept(metadata, event)` beside the plain `feed.accept(event)`, so call the two-argument form when the broker message carries the stream id, version or position, and the one-argument form when it does not. A projection keyed on metadata (such as the stream id) that is fed through the one-argument form now fails loud with an `IllegalStateException` instead of silently dropping the event.
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -136,6 +136,7 @@ permalink: /documentation
 * * * [Effects Are Data](#saga-effects)
 * * * [Running a Saga](#running-a-saga)
 * * * [The `@Saga` Annotation](#the-saga-annotation)
+* * * * [Fed from a broker](#saga-push-source)
 * * * [Delivery Contract](#saga-delivery-contract)
 * * * [Running Across Multiple Instances](#saga-multi-instance)
 * * * [Side Effects and Compensation](#saga-side-effects)
@@ -5025,8 +5026,119 @@ The annotation and the DSL class share the name `Saga`, so a Java factory method
 | `capability` | `AGNOSTIC` (both stream and DCB events) or `STREAM` (stream events only). |
 | `store` / `storeName` | Select the `SagaStateStore` bean by type or name. With both unset the store resolves by convention, the unique `SagaStateStore` bean, otherwise a zero-config MongoDB store in a `saga-<id>` collection. |
 | `commandDispatcher` / `commandDispatcherName` | Select the `CommandDispatcher` bean by type or name, otherwise the unique `CommandDispatcher` bean. There is no default dispatcher, since it is usually a lambda over your `ApplicationService`. |
+| `source` | `EVENT_STORE` (the default) reads the event store. `PUSH` feeds the saga from a `PushSubscriptionModel` bean instead, see [Fed from a broker](#saga-push-source). |
+| `catchup` | For a push saga only. `FROM_EVENT_STORE` (the default) replays history once before going live, `NONE` takes live events only and needs no event store. |
+| `subscriptionModel` / `subscriptionModelName` | Select the `PushSubscriptionModel` bean by type or name when `source = PUSH`. |
 
 `@Saga` is blocking-only in this first version, the reactive starter does not register it.
+
+#### Fed from a broker {#saga-push-source}
+
+A saga does not have to read the event store. Set `source = Source.PUSH` and point it at a [`PushSubscriptionModel`](#push-subscription-blocking) bean, and it reacts to whatever your listener hands that model, from RabbitMQ, Kafka, an HTTP endpoint or anything else:
+
+{% capture kotlin %}
+import org.occurrent.annotation.Saga
+import org.occurrent.annotation.Source
+
+@Component
+class OrderFulfillmentSaga {
+
+    @Saga(id = "order-fulfillment", source = Source.PUSH, subscriptionModelName = "orderEvents")
+    fun orderFulfillment() = saga {
+        correlateAll { it.orderId }
+        startsOn<OrderPlaced> { order ->
+            issue(ReservePayment(order.orderId, order.amount))
+        }
+        step("awaiting-payment") {
+            on<PaymentReserved>(then = end) { payment -> issue(ShipOrder(payment.orderId)) }
+        }
+    }
+}
+
+@Bean("orderEvents")
+fun orderEvents() = PushSubscriptionModel()
+{% endcapture %}
+{% capture java %}
+import org.occurrent.annotation.Saga;
+import org.occurrent.annotation.Source;
+
+@Component
+class OrderFulfillmentSaga {
+
+    @Saga(id = "order-fulfillment", source = Source.PUSH, subscriptionModelName = "orderEvents")
+    org.occurrent.dsl.saga.Saga<OrderEvent, FlowState<OrderEvent>, OrderCommand> orderFulfillment() {
+        return FlowSaga.<OrderEvent, OrderCommand>builder()
+                .correlateAll(OrderEvent::orderId)
+                .startsOn(OrderPlaced.class,
+                        order -> List.of(new ReservePayment(order.orderId(), order.amount())))
+                .step("awaiting-payment", step -> step
+                        .on(PaymentReserved.class, Continuation.end(),
+                                payment -> List.of(new ShipOrder(payment.orderId()))))
+                .build();
+    }
+}
+
+@Bean("orderEvents")
+PushSubscriptionModel orderEvents() {
+    return new PushSubscriptionModel();
+}
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+Your listener calls `accept(cloudEvent)` on that bean and the saga takes it from there. Nothing else changes: the same `correlateAll`, the same steps, the same timeouts, the same state store.
+
+By default the starter puts a [replay in front of the feed](#push-subscription-blocking), so a saga that has never run works through the event store's history first and only then starts taking live events. That is what you want when this application wrote the events and the broker is only how they reach the saga.
+
+##### When the events are not in your event store
+
+If another application writes the events, your event store does not hold them, so there is nothing to replay. A replay would either find nothing or, worse, apply unrelated events that happen to live in the same store. Say so with `catchup = Catchup.NONE`:
+
+{% capture kotlin %}
+@Saga(id = "shipment-tracking", source = Source.PUSH, subscriptionModelName = "warehouseEvents",
+      catchup = Catchup.NONE)
+fun shipmentTracking() = saga { /* ... */ }
+{% endcapture %}
+{% capture java %}
+@Saga(id = "shipment-tracking", source = Source.PUSH, subscriptionModelName = "warehouseEvents",
+      catchup = Catchup.NONE)
+org.occurrent.dsl.saga.Saga<ShipmentEvent, FlowState<ShipmentEvent>, ShipmentCommand> shipmentTracking() {
+    return /* ... */;
+}
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+This takes live events only and touches no event store at all, so the application needs neither a `PositionOrderedReader` nor a `CheckpointStorage` bean. Leave the default in place without those beans and startup fails with a message telling you to set `catchup = Catchup.NONE`, rather than a bare missing-bean error.
+
+A saga that has run before picks up where it left off either way, because its per-instance state lives in its `SagaStateStore` and not in the feed. The difference shows on a first run against an existing history. With the default the saga is brought up to date from the event store before it reacts. With `Catchup.NONE` it starts from nothing and reacts only to what arrives from here on.
+
+##### Forward the Occurrent extensions
+
+A saga recognises a redelivered event by its `streamid` together with its `streamversion`, or by its `position`. A broker delivers at least once, so an event that arrives without any of those is reacted to a second time and its commands are issued again. Occurrent's own stored events always carry them, so this is about what your listener forwards, not about the event store. The saga logs a warning the first time it sees an event without them, naming the saga so you can find it.
+
+This is also why a `@Saga` accepts only a `PushSubscriptionModel` and not a [`DomainEventFeed`](#feeding-domain-events-instead-of-cloudevents), which a `@Projection` does accept. A domain event feed carries no stream metadata, so a saga bound to one would lose its redelivery protection without saying anything.
+
+##### What a push saga cannot set
+
+`startAt`, `startAtGlobalPosition` and `resumeBehavior` are rejected rather than quietly ignored. A replay always starts at the beginning, and where the live feed resumes after a restart is the broker's business. Occurrent records only a one-shot marker that the catch-up finished, so a restart skips the replay and lets the broker redeliver whatever the consumer had not acknowledged.
+
+`startupMode` does apply, under the default `catchup`, because that replay is real work on the startup path. Use `StartupMode.BACKGROUND` to keep a long history from holding up startup. It is rejected together with `Catchup.NONE`, where there is no replay to wait for. Setting `catchup` on an event-store saga is rejected too, since ignoring it would leave the saga reading the whole history it was asked to skip.
+
+##### Starting it yourself
+
+A push feed is a bean you supply, so `occurrent.subscription.mode=manual` cannot withhold it the way it withholds a subscription Occurrent owns. Inject `ManualStartPushSources` and start the saga when the application is ready, which is what you want for a saga behind a leader election, where every node would otherwise react to the same event:
+
+```java
+@Autowired
+ManualStartPushSources pushSources;
+
+void becameLeader() {
+    pushSources.start("order-fulfillment");
+}
+```
+
+`startAll()` starts every withheld push source, projections and sagas alike, and `pendingIds()` says what is still waiting. The saga's instances are readable through [`SagaInstances`](#observing-saga-instances) while it waits, since that reads the state store rather than a running subscription, so you can look at what is in flight before deciding to start it.
+
+The design rationale, including why a domain event feed is refused and why the timers wait for the handover, is in [ADR 0096](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0096-a-push-fed-saga-may-have-no-history-to-replay.md).
 
 ### Delivery Contract {#saga-delivery-contract}
 


### PR DESCRIPTION
Documents `@Saga(source = PUSH)`, which landed in johanhaleby/occurrent#527 and resolves johanhaleby/occurrent#349.

**Do not merge until 0.32.0 is released.** Everything here describes unreleased API.

A new "Fed from a broker" subsection under the `@Saga` annotation, plus three attribute rows in its table and a table of contents entry. It covers:

- Picking the `PushSubscriptionModel` bean, with a full Kotlin and Java example.
- The default replay-then-live catch-up, and `catchup = NONE` for a feed carrying another application's events, which is the case where there is no local history to replay.
- The CloudEvent extensions a listener has to forward, and why a `@Saga` refuses a `DomainEventFeed` when a `@Projection` accepts one.
- What a push saga cannot set, and the one attribute it can (`startupMode`, under the default `catchup`).
- Starting one yourself with `ManualStartPushSources`, which is what a saga behind a leader election needs.

One thing I noticed while writing it: `occurrent.subscription.mode` isn't documented in this repo at all yet, so the manual-start part names the property without linking anywhere. That property also ships in 0.32.0, so it needs its own section before release, and this text should link to it once that exists.

I checked that every anchor I link to resolves. The site build fails locally on an SCSS conversion error in `assets/css/style.scss`, which also fails on a clean checkout of `main`, so it isn't from this change, but it does mean I could not render the page to look at it.
