### PR TITLE
Link the subscription life-cycle testing advice to the testing extension docs

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3142,7 +3142,7 @@ pause the subscription, but it can later be resumed using the `resumeSubscriptio
 Many of the methods in the `SubscriptionLifeCycle` are good to have when you write integration tests.
 It's often useful to e.g. write events to the event store _without_ triggering all subscriptions listening to the events. The life cycle methods allow you to selectively start/stop individual subscriptions so that you can (integration) test them in isolation.
 
-You don't have to drive this by hand in your tests though. The `occurrent-testing-junit-jupiter` extension stops every subscription model by default and lets each test opt subscriptions back in, as described in [Integration Testing](#integration-testing), including [using the subscription life cycle](#testing-subscription-lifecycle) and [stopping every subscription, then opting in](#testing-subscription-deny-by-default).
+You don't have to drive this by hand in your tests though. The `occurrent-testing-junit-jupiter-blocking` extension stops every subscription model by default and lets each test opt subscriptions back in, as described in [Integration Testing](#integration-testing), including [using the subscription life cycle](#testing-subscription-lifecycle) and [stopping every subscription, then opting in](#testing-subscription-deny-by-default).
 
 ## Reactive Subscriptions
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3140,7 +3140,9 @@ Note the difference between canceling and pausing a subscription. Canceling a su
 pause the subscription, but it can later be resumed using the `resumeSubscription` method.
 
 Many of the methods in the `SubscriptionLifeCycle` are good to have when you write integration tests.
-It's often useful to e.g. write events to the event store _without_ triggering all subscriptions listening to the events. The life cycle methods allows you to selectively start/stop individual subscriptions so that you can (integration) test them in isolation.
+It's often useful to e.g. write events to the event store _without_ triggering all subscriptions listening to the events. The life cycle methods allow you to selectively start/stop individual subscriptions so that you can (integration) test them in isolation.
+
+You don't have to drive this by hand in your tests though. The `occurrent-testing-junit-jupiter` extension stops every subscription model by default and lets each test opt subscriptions back in, as described in [Integration Testing](#integration-testing), including [using the subscription life cycle](#testing-subscription-lifecycle) and [stopping every subscription, then opting in](#testing-subscription-deny-by-default).
 
 ## Reactive Subscriptions
 


### PR DESCRIPTION
The Subscription Life-cycle section tells readers the life cycle methods are useful for integration tests but never points them at the Testing chapter that actually documents this. I added two sentences pointing to Integration Testing and its two relevant sections on the testing extension. I also fixed a small grammar slip in the same paragraph, "allows" to "allow".
