### PR TITLE
Document the published MongoDB flush, and why it deletes rather than drops

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -5760,34 +5760,33 @@ Two more worth knowing. `waitUntilStarted()` closes the race between subscribing
 
 Pausing the subscriptions a test does not want works until somebody adds a subscription to the application. The new one then runs in every test that never mentioned it, and a test that used to pass can start failing for a reason nowhere in its own code.
 
-Turning the default around removes that whole class of problem. Stop the entire subscription model before each test, and let each test name what it needs:
+Turning the default around removes that whole class of problem. Stop the entire subscription model before each test, and let each test name what it needs. `occurrent-testing-junit-jupiter` is the JUnit 5 extension that does it:
 
-```java
-class StopSubscriptionsExtension implements BeforeEachCallback, AfterEachCallback {
-
-    private final SubscriptionModel subscriptionModel;
-
-    StopSubscriptionsExtension(SubscriptionModel subscriptionModel) {
-        this.subscriptionModel = subscriptionModel;
-    }
-
-    @Override
-    public void beforeEach(ExtensionContext context) {
-        subscriptionModel.stop();
-    }
-
-    @Override
-    public void afterEach(ExtensionContext context) {
-        subscriptionModel.stop();
-    }
-
-    void start(String subscriptionId) {
-        subscriptionModel.resumeSubscription(subscriptionId).waitUntilStarted();
-    }
-}
+```xml
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-testing-junit-jupiter</artifactId>
+    <version>{{site.occurrentversion}}</version>
+    <scope>test</scope>
+</dependency>
 ```
 
-`stop()` leaves every running subscription paused rather than cancelled, which is what lets `resumeSubscription` bring them back one at a time. Keeping `waitUntilStarted()` inside the helper means no test can forget it.
+It depends on JUnit and the blocking subscription API and nothing else, so it works without Spring and without a container:
+
+{% capture java %}
+@RegisterExtension
+static final OccurrentSubscriptionsExtension subscriptions =
+        OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel);
+{% endcapture %}
+{% capture kotlin %}
+@JvmField
+@RegisterExtension
+val subscriptions = subscriptionModel.stoppedByDefault()
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+<div class="comment">Kotlin needs the "@JvmField", or JUnit never picks the field up and every subscription stays live.</div>
+
+`stop()` leaves every running subscription paused rather than cancelled, which is what lets the extension bring them back one at a time. `start(id)` waits until the subscription is really listening before it returns, so no test can forget that and race its own write.
 
 A test now opens with its own dependency list:
 
@@ -5809,12 +5808,69 @@ If you also flush the database between tests, stop the subscriptions first, and 
 ```java
 @RegisterExtension
 @Order(1)
-StopSubscriptionsExtension subscriptions = new StopSubscriptionsExtension(subscriptionModel);
+OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel);
 
 @RegisterExtension
 @Order(2)
 FlushDatabaseExtension flush = new FlushDatabaseExtension(mongoTemplate);
 ```
+
+### Naming several subscriptions, or all of them {#testing-subscription-starting-several}
+
+Two shortcuts for the cases where naming one id per test is the wrong shape.
+
+`alwaysStart` names subscriptions that every test in the class needs, resumed in `beforeEach` right after the stop, so individual tests do not repeat themselves:
+
+```java
+OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel).alwaysStart("order-projection")
+```
+
+`startAll()` starts every subscription the model has, which is how you write the one test that checks two subscriptions reacting to the same event. It returns the ids it started, and skips any a test already started:
+
+```java
+subscriptions.startAll();
+```
+
+Both rest on the model being able to list its subscriptions, through `IntrospectableSubscriptionModel`. The in-memory, Spring MongoDB and native MongoDB models implement it, and so does the competing consumer model, which also reports a consumer still waiting for its lock. Name an id that does not exist and the failure tells you the ids that do, instead of only repeating the one you got wrong.
+
+### Wiring it into a Spring Boot test {#testing-subscription-spring-boot}
+
+`occurrent-testing-spring-boot` wires the same extension into the application context, so a test autowires it rather than constructing it:
+
+```xml
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-testing-spring-boot</artifactId>
+    <version>{{site.occurrentversion}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+{% capture java %}
+@SpringBootTest
+@EnableOccurrentTesting
+class OrderProjectionTest {
+
+    @Autowired
+    @RegisterExtension
+    OccurrentSubscriptionsExtension subscriptions;
+}
+{% endcapture %}
+{% capture kotlin %}
+@SpringBootTest
+@EnableOccurrentTesting
+class OrderProjectionTest {
+
+    @Autowired
+    @RegisterExtension
+    lateinit var subscriptions: OccurrentSubscriptionsExtension
+}
+{% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
+
+The extension bean is all `@EnableOccurrentTesting` adds. Your event store and subscription model are left exactly as the application wires them, so the test still runs against the real store. That is the point, since a subscription is only worth testing against the change streams, checkpoints and catch-up it actually uses.
+
+Your application registers its subscriptions at startup through its annotations, so a test never registers them itself. Outside Spring, register them once in `@BeforeAll`. Doing it in `@BeforeEach` fails on the second test with `Subscription <id> is already defined`, and would not work anyway, because JUnit runs an extension's `beforeEach` before any `@BeforeEach` method, so a subscription created there is never stopped.
 
 While flushing, delete the documents instead of dropping the collections or the database. Dropping them invalidates a live MongoDB change stream, and the subscriptions you resume afterwards then receive nothing.
 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -5760,12 +5760,12 @@ Two more worth knowing. `waitUntilStarted()` closes the race between subscribing
 
 Pausing the subscriptions a test does not want works until somebody adds a subscription to the application. The new one then runs in every test that never mentioned it, and a test that used to pass can start failing for a reason nowhere in its own code.
 
-Turning the default around removes that whole class of problem. Stop the entire subscription model before each test, and let each test name what it needs. `occurrent-testing-junit-jupiter` is the JUnit 5 extension that does it:
+Turning the default around removes that whole class of problem. Stop the entire subscription model before each test, and let each test name what it needs. `occurrent-testing-junit-jupiter-blocking` is the JUnit 5 extension that does it:
 
 ```xml
 <dependency>
     <groupId>org.occurrent</groupId>
-    <artifactId>occurrent-testing-junit-jupiter</artifactId>
+    <artifactId>occurrent-testing-junit-jupiter-blocking</artifactId>
     <version>{{site.occurrentversion}}</version>
     <scope>test</scope>
 </dependency>

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -5803,17 +5803,27 @@ void order_projection_is_updated_when_an_order_is_placed() {
 
 Stopping in `afterEach` matters as much as in `beforeEach`. Spring caches the test context across test classes, so a subscription that one class resumed is still running when the next class starts.
 
-If you also flush the database between tests, stop the subscriptions first, and pin the order with `@Order` rather than relying on the order of the fields:
+If you also empty the database between tests, hand that to the same extension rather than registering a second one. It runs after every subscription is stopped and before any is resumed, which is the only order that works, and `clearingCheckpoints` takes care of the checkpoints:
 
 ```java
 @RegisterExtension
-@Order(1)
-OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel);
-
-@RegisterExtension
-@Order(2)
-FlushDatabaseExtension flush = new FlushDatabaseExtension(mongoTemplate);
+OccurrentSubscriptionsExtension subscriptions = OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel)
+        .clearingStateWith(OccurrentMongoFlush.everyCollectionIn(mongoTemplate.getDb()))
+        .clearingCheckpoints(checkpointStorage);
 ```
+
+`OccurrentMongoFlush` comes from `occurrent-testing-mongodb`:
+
+```xml
+<dependency>
+    <groupId>org.occurrent</groupId>
+    <artifactId>occurrent-testing-mongodb</artifactId>
+    <version>{{site.occurrentversion}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+`clearingStateWith` takes any `Runnable`, so a store other than MongoDB fits the same shape.
 
 ### Naming several subscriptions, or all of them {#testing-subscription-starting-several}
 
@@ -5872,9 +5882,17 @@ The extension bean is all `@EnableOccurrentTesting` adds. Your event store and s
 
 Your application registers its subscriptions at startup through its annotations, so a test never registers them itself. Outside Spring, register them once in `@BeforeAll`. Doing it in `@BeforeEach` fails on the second test with `Subscription <id> is already defined`, and would not work anyway, because JUnit runs an extension's `beforeEach` before any `@BeforeEach` method, so a subscription created there is never stopped.
 
-While flushing, delete the documents instead of dropping the collections or the database. Dropping them invalidates a live MongoDB change stream, and the subscriptions you resume afterwards then receive nothing.
+`everyCollectionIn` deletes the documents rather than dropping anything, which matters for two reasons.
 
-Flush the checkpoint collection along with the events, `subscriptions` unless you changed `occurrent.subscription.collection`. Resuming a subscription continues from its stored checkpoint, so a subscription left behind by an earlier test picks up whatever that test wrote while it was stopped, and the second test then sees events it never wrote. Clearing the events alone does not prevent this, because the checkpoint is what decides where the resume starts.
+Dropping a collection or a database invalidates a live MongoDB change stream, and the subscriptions you resume afterwards then receive nothing. Stopping the model first does not save you, because it resumes from a position that points into a collection which no longer exists.
+
+The quieter reason is that your event store creates its unique indexes when it is constructed, so dropping removes them and only a new store brings them back. Spring caches the test context, so nothing constructs one again, and your optimistic-concurrency and duplicate-detection tests keep passing for the rest of the run with no index behind them. That failure never announces itself, which makes it the worse of the two.
+
+It names no collections, on purpose. Occurrent writes to more of them than you are likely to remember: the events, a stream position collection, a DCB checkpoint collection, the checkpoint collection below, and a competing consumer lock collection. A list you maintain by hand stops covering one the day you switch a feature on. Use `collectionsIn(database, ..)` only when the database holds something a test has to keep, and `except(..)` to spare one collection from the sweep.
+
+For the one case deleting cannot serve, a test asserting that a collection or an index does *not* exist, there is `droppingTheDatabaseIn(database)`. Nothing else should reach for it.
+
+The checkpoints have to go too, which is what `clearingCheckpoints` is for. Resuming a subscription continues from its stored checkpoint, so a subscription left behind by an earlier test picks up whatever that test wrote while it was stopped, and the second test then sees events it never wrote. Clearing the events alone does not prevent this, because the checkpoint is what decides where the resume starts. It works through `CheckpointStorage` rather than a collection name, so it is right whether your checkpoints live beside the events or in Redis.
 
 The in-memory subscription model does not have this problem. Events written while a subscription is stopped are dropped rather than queued, so there is nothing to catch up on when a later test starts it again.
 


### PR DESCRIPTION
Held for release, like the others, since `occurrent-testing-mongodb` ships in 0.32.0 (occurrent#520, ADR 95).

**Stacked on #22**, which is where the testing chapter first names `occurrent-testing-junit-jupiter`. This edits the same section, so basing it on `main` would have meant writing against text that is not there yet and conflicting with #22 at release time. Merge #22 first.

The chapter already told the reader the two rules, delete documents rather than dropping, and flush the checkpoint collection, and then left them to implement both with a hand-rolled extension whose order they had to pin with `@Order`. Both are library behaviour now, composed into the extension that already stops the subscriptions, so nothing has to be ordered:

```java
OccurrentSubscriptionsExtension.stoppedByDefault(subscriptionModel)
        .clearingStateWith(OccurrentMongoFlush.everyCollectionIn(mongoTemplate.getDb()))
        .clearingCheckpoints(checkpointStorage);
```

Three things are new rather than reworded.

`everyCollectionIn` names no collections, and the docs now say why that is the point rather than a convenience: Occurrent writes to the events, a stream position collection, a DCB checkpoint collection, the checkpoint collection, and a competing consumer lock collection, so a list you keep by hand stops covering one the day you switch a feature on.

The second reason to delete rather than drop is written down for the first time. Dropping destroys the event store's unique indexes, which are created when the store is constructed, so a cached Spring test context never brings them back and optimistic-concurrency and duplicate-detection tests keep passing with no index behind them. That one never announces itself, which makes it worse than the change stream going quiet.

`clearingCheckpoints` works through `CheckpointStorage` rather than a collection name, so the guidance is now right for checkpoints kept in Redis, which the old paragraph naming the `subscriptions` collection was not.

`droppingTheDatabaseIn` is mentioned once, for the case deleting cannot serve, a test asserting a collection or an index does not exist.

