### PR TITLE
Fix the docs site's outdated 0.32.0 time-rewrite script

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -2519,15 +2519,25 @@ If the range-filter gap matters to you, rewrite the `time` field of existing doc
 
 ```js
 db.events.updateMany(
-  { time: { $type: "string" } },
+  {
+    $and: [
+      { time: { $type: "string" } },
+      { time: { $not: /\.\d{4,}/ } }
+    ]
+  },
   [
     {
       $set: {
         time: {
-          $dateToString: {
-            date: { $dateFromString: { dateString: "$time" } },
-            format: "%Y-%m-%dT%H:%M:%S.%LZ"
-          }
+          $concat: [
+            {
+              $dateToString: {
+                date: { $dateFromString: { dateString: "$time" } },
+                format: "%Y-%m-%dT%H:%M:%S.%L"
+              }
+            },
+            "000000Z"
+          ]
         }
       }
     }
@@ -2535,7 +2545,11 @@ db.events.updateMany(
 )
 ```
 
-Two things to know before running it. `$dateFromString` parses into a BSON date, which holds milliseconds, so this loses any precision finer than a millisecond that was in the stored string. If your events carry microseconds or nanoseconds and you need to keep them, do the rewrite in application code instead, reading each `time` with `OffsetDateTime.parse` and writing it back formatted with nine fractional digits. And `%L` emits three fractional digits, not nine, so this script does not produce the true canonical shape described above. It gives every rewritten value the same three-digit shape instead, which is enough for them to sort correctly against each other, but it is a different, shorter shape than what this version writes for new events. Comparisons between rewritten values still behave, but an exact filter built from a nanosecond instant will not match a rewritten value, since the rewritten value only has three fractional digits to compare. Use the application-code route above if you need that precision back.
+The match stage skips a value whose fractional part already has more than three digits. `$dateFromString` parses into a BSON date, which only holds milliseconds, so touching a value that already carries more precision than that would throw the extra digits away. That protects two kinds of document from the same mistake. One is an event whose original timestamp genuinely had sub-millisecond precision. The other is an event 0.32.0 already wrote in the canonical nine-digit shape, which this script must not touch a second time either.
+
+For an event the script does rewrite, it pads the three digits `$dateToString` produces out to nine with zeroes, so the result has the canonical fixed width and sorts correctly against the values 0.32.0 writes for new events. Those zeroes are filler, not real digits, so a rewritten value equals the canonical shape a filter checks only when the original event had no sub-millisecond precision to lose in the first place.
+
+An event the script skips keeps the shape it already had. An equality filter still matches it exactly as it did before you ran anything, through the legacy shape described above, because its stored value never changed. What stays open for it is the range-query gap. If you want that fixed too, rewrite it in application code instead, reading it with `OffsetDateTime.parse` and writing it back with nine real fractional digits, since only that route can supply digits `$dateFromString` would otherwise discard.
 
 **Important**: There's yet another option! If you don't need nanotime precision (i.e you're fine with millisecond precision) _and_ you're OK with always representing the "time" attribute in UTC, then you can use
 `TimeRepresentation.DATE` without loss of precision! This is why, if `DATE` is configured for the `EventStore`, Occurrent will refuse to store a `CloudEvent` that specifies nanotime 

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -2545,7 +2545,7 @@ db.events.updateMany(
 )
 ```
 
-The match stage skips a value whose fractional part already has more than three digits. `$dateFromString` parses into a BSON date, which only holds milliseconds, so touching a value that already carries more precision than that would throw the extra digits away. That protects two kinds of document from the same mistake. One is an event whose original timestamp genuinely had sub-millisecond precision. The other is an event 0.32.0 already wrote in the canonical nine-digit shape, which this script must not touch a second time either.
+The match stage skips a value whose fractional part already has more than three digits. `$dateFromString` parses into a BSON date, which only holds milliseconds, so touching a value that already carries more precision than that would throw the extra digits away. That protects two kinds of document from the same mistake. One is an event whose original timestamp genuinely had sub-millisecond precision. The other is an event that 0.32.0 already wrote in the canonical nine-digit shape, which this script must not touch a second time either.
 
 For an event the script does rewrite, it pads the three digits `$dateToString` produces out to nine with zeroes, so the result has the canonical fixed width and sorts correctly against the values 0.32.0 writes for new events. Those zeroes are filler, not real digits, so a rewritten value equals the canonical shape a filter checks only when the original event had no sub-millisecond precision to lose in the first place.
 


### PR DESCRIPTION
I ported the fixed 0.32.0 time-rewrite script from the library's upgrade guide (johanhaleby/occurrent#652) into the site's copy in `pages/docs/docs.md`. The old script here still zero-padded nothing and left rewritten values at three fractional digits, which matches neither the canonical nor the legacy shape the `eq`/`in`/`ne` filter handling checks against, so it broke equality filters on any event with real sub-millisecond precision.

The new script skips a value whose fractional part already has more than three digits, and pads the rest to the canonical nine-digit width. I replaced the explanatory paragraph below it with the corrected version from the guide, describing what the match stage protects, what the padding actually gives you, and what stays true for a value the script skips.

The change is limited to that one script and its explanation. I checked the ported script text against the guide's and it is byte-identical.

Fixes johanhaleby/occurrent#653.

## Verification

```
export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
bundle install
bundle exec jekyll build
```

Both ran clean, exit 0, and the rendered `documentation.html` carries the new script and prose.
