### PR TITLE
Document waiting-consumer pause fix for competing consumer subscriptions

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3511,8 +3511,8 @@ Since 0.32.0, `CompetingConsumerSubscriptionModel` refuses two calls it used to 
 Pausing a subscription whose consumer is still waiting for the lock now works too, instead of being silently ignored. Before this fix, `pauseSubscription(id)` on a waiting consumer logged the call and returned as if it had succeeded, `isPaused(id)` kept answering `false`, and the consumer started anyway the moment the lock arrived. Pausing a waiting consumer now unregisters it from the strategy, so the lock never arrives while it's paused, and `isPaused(id)` answers `true` for it right away. `resumeSubscription(id)` registers it again as a lock candidate.
 
 ```java
-subscriptionModel.pauseSubscription("orders"); // works even before this node has won the lock
-subscriptionModel.isPaused("orders"); // true, whether or not the lock ever arrived
+competingConsumerSubscriptionModel.pauseSubscription("orders"); // works even before this node has won the lock
+competingConsumerSubscriptionModel.isPaused("orders"); // true, whether or not the lock ever arrived
 ```
 
 `isRunning(id)` doesn't change. It still answers `false` for a consumer that hasn't won the lock, paused or not, which is what a saga's timer poller relies on to stay off a node that isn't delivering.

--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -3508,6 +3508,17 @@ If the above code is executed on multiple nodes/processes, then only *one* subsc
 
 Since 0.32.0, `CompetingConsumerSubscriptionModel` refuses two calls it used to accept quietly, both scoped to one model instance rather than to the subscription id across the cluster. Running the same subscription id on several nodes is untouched, since that's the whole point of the pattern. Subscribing twice to one subscription id on one instance now throws `DuplicateSubscriptionIdException`, matching what every other subscription model already did, and pausing a subscription this instance never had now throws `UnknownSubscriptionException` instead of doing nothing. Cancelling a subscription that opted out of competing consumption now also frees its subscription id, where the model used to remember it forever.
 
+Pausing a subscription whose consumer is still waiting for the lock now works too, instead of being silently ignored. Before this fix, `pauseSubscription(id)` on a waiting consumer logged the call and returned as if it had succeeded, `isPaused(id)` kept answering `false`, and the consumer started anyway the moment the lock arrived. Pausing a waiting consumer now unregisters it from the strategy, so the lock never arrives while it's paused, and `isPaused(id)` answers `true` for it right away. `resumeSubscription(id)` registers it again as a lock candidate.
+
+```java
+subscriptionModel.pauseSubscription("orders"); // works even before this node has won the lock
+subscriptionModel.isPaused("orders"); // true, whether or not the lock ever arrived
+```
+
+`isRunning(id)` doesn't change. It still answers `false` for a consumer that hasn't won the lock, paused or not, which is what a saga's timer poller relies on to stay off a node that isn't delivering.
+
+This also narrows what `SubscriptionModelLifeCycle.pauseSubscription` refuses. It used to describe the refusal as covering a subscription that "is not running, because it is already paused, was never started, or the whole model is stopped." Not currently delivering is no longer, on its own, a reason to refuse. A subscription that has started can be paused even while nothing is coming through it right now.
+
 Note that you can make several tweaks to the `CompetingConsumerStrategy` using the `Builder`, (`new NativeMongoLeaseCompetingConsumerStrategy.Builder()` or `new SpringMongoLeaseCompetingConsumerStrategy.Builder()`). 
 You can, for example, tweak how long the lease time should be for the lock (default is 20 seconds), the name of lease collection in MongoDB, as well as the retry strategy and other things. 
 


### PR DESCRIPTION
I added a paragraph to the Competing Consumer Subscription section in `pages/docs/docs.md`, right after the existing "Since 0.32.0" paragraph on pause/subscribe/cancel behaviour, since this is the same class of fix.

It covers what johanhaleby/occurrent#655 (fixes #565, [ADR 112](https://github.com/johanhaleby/occurrent/blob/main/doc/architecture/decisions/0112-a-competing-consumer-can-be-paused-while-still-waiting-for-the-lock.md)) changed:

- Pausing a subscription whose consumer is still waiting for the lock now works, instead of being silently ignored (the old behaviour logged and returned as success, and the consumer started anyway once the lock arrived).
- A paused-while-waiting consumer is unregistered from the strategy, so the lock never arrives while it's paused, and `resumeSubscription(id)` registers it again as a lock candidate.
- `isPaused(id)` answers for the model's own waiting and paused consumers, not only what the wrapped model knows. `isRunning(id)` is unchanged, it still answers `false` for a consumer that hasn't won the lock.
- The `SubscriptionModelLifeCycle.pauseSubscription` refusal is narrower now. Not currently delivering is no longer, on its own, a reason to refuse.

Held for the next Occurrent release, since the library fix (squash f8e310db8) hasn't shipped yet. Same convention as the currently held #49. I didn't touch `js/_partials/main.js`'s `addedTags`, that's a release-day step, and this is a behaviour fix rather than something for `_posts`.

Verified `bundle exec jekyll build` renders the new paragraph cleanly (`documentation.html`), and the diff is additive only, no front matter or anchors touched.
