### PR TITLE
Fix overclaimed projection filter safety in the docs

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -5227,7 +5227,11 @@ val enrolledStudents = projection<Int, CourseEvent, String>(initialState = 0) {
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
-The builder both assembles the `View` and records the event types you registered handlers for, so the subscription that feeds the projection is filtered to exactly those events. There's no separate list of subscribed types to keep in sync with the fold. The fold returns the state unchanged for any event type without a handler, so it's always safe to point a projection at a broader stream than it handles. When you need to select on more than the event type, for example a subject, a source, or a time range, set an explicit `filter(...)` on the builder.
+The builder both assembles the `View` and records the event types you registered handlers for, so the subscription that feeds the projection is filtered to exactly those events. There's no separate list of subscribed types to keep in sync with the fold. The fold returns the state unchanged for any event type without a handler, so pointing a projection at a broader stream is safe for the fold itself.
+
+That safety has a limit though. Every event the filter admits is still converted to a domain event before the fold ever sees it, and one the converter can't turn into your event type fails that delivery instead of being ignored. A subscription that keeps redelivering a failing event holds up everything queued behind it, so a broader stream is only safe while it stays inside what the converter can convert.
+
+When you need to select on more than the event type, for example a subject, a source, or a time range, set an explicit `filter(...)` on the builder.
 
 ### Single-instance projections
 


### PR DESCRIPTION
The projection chapter said pointing a projection at a broader stream than it handles is always safe, because the fold no-ops on events it doesn't handle. That's true for the fold, but every event the filter admits is still converted to a domain event before the fold sees it, and one the converter can't convert fails that delivery instead of being ignored, stalling the subscription behind it.

I scoped the sentence to say so, and split it into its own paragraph. Matches the same correction going into `Projection`'s javadoc in [occurrent#808](https://github.com/johanhaleby/occurrent/pull/808).
