### PR TITLE
Badge the Step Conditions section as added in 0.33.0

### DIFF
--- a/js/_partials/main.js
+++ b/js/_partials/main.js
@@ -97,6 +97,7 @@ if (document.location.pathname.includes("/documentation")) {
         "synchronous-subscription-life-cycle" : "0.32.0",
         "saga-event-types" : "0.33.0",
         "saga-explicit-filter" : "0.33.0",
+        "saga-step-conditions" : "0.33.0",
         "replay-batching" : "0.33.0",
         "checkpoint-fencing-blocking" : "0.33.0",
         "subscription-model-capabilities" : "0.33.0"


### PR DESCRIPTION
Adds the `saga-step-conditions` entry to `addedTags` so the Step Conditions section carries its Added in v0.33.0 badge. The 0.33.0 closeout verification confirmed this is the only piece still missing after the held docs PRs closed, and issue #57's thread had already flagged it.
