### PR TITLE
Bump the version and announce the 0.34.0 release (hold, merges at 0.34.0 release)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-occurrentversion: 0.33.0
+occurrentversion: 0.34.0
 repourl: https://github.com/occurrent/occurrent.github.io
 description: Occurrent -  Event Sourcing Utilities for the JVM based on the CloudEvent specification
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_posts/news/2026-08-25-0_34_0.md
+++ b/_posts/news/2026-08-25-0_34_0.md
@@ -19,11 +19,11 @@ A saga already worked this way. See the breaking change below for what happens w
 
 ### PushSubscriptionModel gets an observation hook
 
-`PushSubscriptionModel` takes an optional `PushObserver`. Once per event, and before delivery is attempted, the observer is told how the event was routed. It lives in the core library, so it works with or without Spring Boot, and the reactive model takes the same observer.
+`PushSubscriptionModel` takes an optional `PushObserver`. Once per event, the observer is told how that event was routed, as a `RoutingOutcome` rather than a boolean. It lives in the core library, so it works with or without Spring Boot, and the reactive model takes the same observer.
 
-The outcome is one of three values rather than a boolean. `DELIVERED` means a running subscription's filter accepted the event. `FILTERED` means that subscription evaluated it and declined. `NOT_DELIVERABLE` means nothing could safely receive it, whether because no subscription was registered, the model was stopped or paused, or the filter itself failed.
+`DELIVERED` and `FILTERED` mean a running subscription saw the event and either accepted it or declined it. The other four, `UNAVAILABLE`, `NOT_DELIVERABLE`, `DEFERRED` and `REFUSED`, each mean nothing actually received it, for a different reason.
 
-If you acknowledge broker messages, you may acknowledge on the first two outcomes and must never acknowledge on the third. That is what makes a misconfigured queue binding or a type-mapping typo visible instead of silent.
+If you acknowledge broker messages, you may acknowledge on `DELIVERED` once `accept(..)` has returned normally, and on `FILTERED`. Never acknowledge on the other four. That is what makes a misconfigured queue binding or a type-mapping typo visible instead of silent, and [the documentation](/documentation#push-subscription-blocking-observer) says what each outcome means.
 
 ### An asynchronous projection can wait for its own write
 

--- a/_posts/news/2026-08-25-0_34_0.md
+++ b/_posts/news/2026-08-25-0_34_0.md
@@ -4,24 +4,40 @@ category: news
 date: 2026-08-25
 version: 0.34.0
 title: Version 0.34.0 Released
-summary: The flow saga's deprecated join is removed, a projection, subscription, query or snapshot declaring a supertype event is now refused, four MongoDB-only config keys move under mongodb, and a descriptor factory's class-level advice no longer runs at startup
+summary: Sealed event types now expand everywhere, PushSubscriptionModel gets an observation hook, and the flow saga's deprecated join is removed with a recipe, alongside four MongoDB-only config keys moving under mongodb and a descriptor factory's class-level advice no longer running at startup
 ---
 
-Occurrent 0.34.0 is released. There is no new headline feature this time, so this post leads with the breaking changes worth reading before you upgrade.
+Occurrent 0.34.0 is released. It comes with three highlights and four breaking changes worth reading before you upgrade.
 
-## The flow saga's `join` is removed
+## Highlights
 
-The flow saga's deprecated `join`, Kotlin's `expect<T>`, and `Expectation` are gone. `join` was already deprecated in 0.33.0 in favor of `on(StepCondition, ...)` with `allOf(...)`, and that replacement is what every caller now needs. The new `UpgradeToOccurrent_0_34` OpenRewrite recipe rewrites a `join` call built from a literal list of literal `Expectation.of(...)` calls. A list built from a variable or a method call, and every Kotlin call site, are left alone and stop compiling, so the compiler finds them for you.
+### Sealed event types expand everywhere
 
-## A supertype event declaration is now refused everywhere
+Declaring a sealed event supertype now matches every concrete type it permits, in projections, subscriptions built through the subscription DSL, queries through `DomainEventQueries`, and `@Snapshot` views, the same way a saga already did. See the breaking change below for what happens when a declared type cannot be expanded this way.
+
+### PushSubscriptionModel gets an observation hook
+
+`PushSubscriptionModel` takes an optional `PushObserver` that tells you whether each delivered event matched a registered subscription, so a misconfigured queue binding or a type-mapping typo is now visible instead of silent.
+
+### The deprecated `join` is gone, with a recipe for the mechanical part
+
+The flow saga's deprecated `join` is removed. The new `org.occurrent.UpgradeToOccurrent_0_34` recipe rewrites the mechanical call sites to `on(allOf(...))` for you. See the breaking change below for what the recipe cannot reach.
+
+## Breaking changes
+
+### The flow saga's `join` is removed
+
+The flow saga's deprecated `join`, Kotlin's `expect<T>`, and `Expectation` are gone. `join` was already deprecated in 0.33.0 in favor of `on(StepCondition, ...)` with `allOf(...)`, and that replacement is what every caller now needs. The `UpgradeToOccurrent_0_34` recipe rewrites a `join` call built from a literal list of literal `Expectation.of(...)` calls. A list built from a variable or a method call, and every Kotlin call site, are left alone and stop compiling, so the compiler finds them for you.
+
+### A supertype event declaration is now refused everywhere
 
 A projection, a subscription built through the subscription DSL, a query through `DomainEventQueries`, or a `@Snapshot` view that declares an event type whose concrete subtypes cannot be found is now refused, the same refusal 0.33.0 already shipped for a saga and an annotation-based subscription. Seal the hierarchy or declare the concrete event types to fix it, or set an explicit filter where one is available.
 
-## Four MongoDB-only config keys move under `mongodb`
+### Four MongoDB-only config keys move under `mongodb`
 
 `occurrent.event-store.collection`, `occurrent.event-store.time-representation`, `occurrent.subscription.collection` and `occurrent.subscription.restart-on-change-stream-history-lost` are renamed to their `mongodb`-qualified equivalents. Each old key still works and is deprecated, removed in the release after next, and the new recipe rewrites both `.properties` and `.yaml` for you.
 
-## A descriptor factory's class-level advice no longer runs at startup
+### A descriptor factory's class-level advice no longer runs at startup
 
 A `@Projection`, `@Saga` or `@Snapshot` bean's class-level advice, `@Transactional` or a custom aspect for example, no longer runs once at startup as a side effect of its descriptor factory being invoked. That was never a documented behavior, an accident of CGLIB proxying the bean under the default `spring.aop.proxy-target-class=true`. A reactor factory that returns `null` also now fails startup with `IllegalStateException` instead of `IllegalArgumentException`, matching what the blocking stack already threw for the same mistake.
 

--- a/_posts/news/2026-08-25-0_34_0.md
+++ b/_posts/news/2026-08-25-0_34_0.md
@@ -4,20 +4,34 @@ category: news
 date: 2026-08-25
 version: 0.34.0
 title: Version 0.34.0 Released
-summary: Sealed event types now expand everywhere, PushSubscriptionModel gets an observation hook, and the flow saga's deprecated join is removed with a recipe, alongside four MongoDB-only config keys moving under mongodb and a descriptor factory's class-level advice no longer running at startup
+summary: Sealed event types now expand everywhere, PushSubscriptionModel gets an observation hook, an asynchronous projection can wait for its own write, and the flow saga's deprecated join is removed with a recipe, alongside four MongoDB-only config keys moving under mongodb and a descriptor factory's class-level advice no longer running at startup
 ---
 
-Occurrent 0.34.0 is released. It comes with three highlights and four breaking changes worth reading before you upgrade.
+Occurrent 0.34.0 is released. It comes with four highlights and four breaking changes worth reading before you upgrade.
 
 ## Highlights
 
 ### Sealed event types expand everywhere
 
-Declaring a sealed event supertype now matches every concrete type it permits, in projections, subscriptions built through the subscription DSL, queries through `DomainEventQueries`, and `@Snapshot` views, the same way a saga already did. See the breaking change below for what happens when a declared type cannot be expanded this way.
+Declare a sealed event supertype and it now matches every concrete type it permits. That holds for projections, for subscriptions built through the subscription DSL, and for queries through `DomainEventQueries`, none of which need Spring Boot, and for `@Snapshot` views if you use the Spring Boot starter.
+
+A saga already worked this way. See the breaking change below for what happens when a declared type cannot be expanded.
 
 ### PushSubscriptionModel gets an observation hook
 
-`PushSubscriptionModel` takes an optional `PushObserver` that reports each pushed event's `RoutingOutcome` (`DELIVERED`, `FILTERED` or `NOT_DELIVERABLE`), so a misconfigured queue binding or a type-mapping typo is now visible instead of silent.
+`PushSubscriptionModel` takes an optional `PushObserver`. Once per event, and before delivery is attempted, the observer is told how the event was routed. It lives in the core library, so it works with or without Spring Boot, and the reactive model takes the same observer.
+
+The outcome is one of three values rather than a boolean. `DELIVERED` means a running subscription's filter accepted the event. `FILTERED` means that subscription evaluated it and declined. `NOT_DELIVERABLE` means nothing could safely receive it, whether because no subscription was registered, the model was stopped or paused, or the filter itself failed.
+
+If you acknowledge broker messages, you may acknowledge on the first two outcomes and must never acknowledge on the third. That is what makes a misconfigured queue binding or a type-mapping typo visible instead of silent.
+
+### An asynchronous projection can wait for its own write
+
+Every write and DCB append now returns an `AppendId`, and a projection can record which ones it has applied. Wait for a specific append with `AppliedAppendStore.waitUntilApplied(...)` instead of running the whole projection synchronously just to see your own write.
+
+With the Spring Boot starter, set `recordAppliedAppends = true` on `@Projection` and the store and the recording are wired for you. Without Spring Boot, wrap the projection yourself with `Projections.recordingAppliedAppends(..)` and register the wrapper on your subscription model.
+
+See [the documentation](/documentation#projection-annotation-applied-appends) for the worked example and what the wait does and doesn't guarantee.
 
 ### The deprecated `join` is gone, with a recipe for the mechanical part
 
@@ -27,18 +41,28 @@ The flow saga's deprecated `join` is removed. The new `org.occurrent.UpgradeToOc
 
 ### The flow saga's `join` is removed
 
-The flow saga's deprecated `join`, Kotlin's `expect<T>`, and `Expectation` are gone. `join` was already deprecated in 0.33.0 in favor of `on(StepCondition, ...)` with `allOf(...)`, and that replacement is what every caller now needs. The `UpgradeToOccurrent_0_34` recipe rewrites a `join` call built from a literal list of literal `Expectation.of(...)` calls. A list built from a variable or a method call, and every Kotlin call site, are left alone and stop compiling, so the compiler finds them for you.
+The flow saga's deprecated `join`, Kotlin's `expect<T>`, and `Expectation` are gone. That is the saga DSL itself, so it affects you whether or not you run Spring Boot.
+
+`join` was already deprecated in 0.33.0 in favor of `on(StepCondition, ...)` with `allOf(...)`, and that replacement is what every caller now needs.
+
+The `UpgradeToOccurrent_0_34` recipe rewrites a `join` call built from a literal list of literal `Expectation.of(...)` calls. A list built from a variable or a method call, and every Kotlin call site, are left alone and stop compiling, so the compiler finds them for you.
 
 ### A supertype event declaration is now refused everywhere
 
-A projection, a subscription built through the subscription DSL, a query through `DomainEventQueries`, or a `@Snapshot` view that declares an event type whose concrete subtypes cannot be found is now refused, the same refusal 0.33.0 already shipped for a saga and an annotation-based subscription. Seal the hierarchy or declare the concrete event types to fix it, or set an explicit filter where one is available.
+Declaring an event type whose concrete subtypes cannot be found is now refused in a projection, in a subscription built through the subscription DSL, in a query through `DomainEventQueries`, and in a `@Snapshot` view. It is the same refusal 0.33.0 already shipped for a saga and for an annotation-based subscription.
+
+Seal the hierarchy or declare the concrete event types to fix it, or set an explicit filter where one is available.
 
 ### Four MongoDB-only config keys move under `mongodb`
 
-`occurrent.event-store.collection`, `occurrent.event-store.time-representation`, `occurrent.subscription.collection` and `occurrent.subscription.restart-on-change-stream-history-lost` are renamed to their `mongodb`-qualified equivalents. Each old key still works and is deprecated, removed in the release after next, and the new recipe rewrites both `.properties` and `.yaml` for you.
+The rename only reaches you if you configure Occurrent through Spring Boot properties. `occurrent.event-store.collection`, `occurrent.event-store.time-representation`, `occurrent.subscription.collection` and `occurrent.subscription.restart-on-change-stream-history-lost` are renamed to their `mongodb`-qualified equivalents.
+
+Each old key still works and is deprecated, and it will be removed in the release after next. The new recipe rewrites both `.properties` and `.yaml` for you.
 
 ### A descriptor factory's class-level advice no longer runs at startup
 
-A `@Projection`, `@Saga` or `@Snapshot` bean's class-level advice, `@Transactional` or a custom aspect for example, no longer runs once at startup as a side effect of its descriptor factory being invoked. That was never a documented behavior, an accident of CGLIB proxying the bean under the default `spring.aop.proxy-target-class=true`. A reactor factory that returns `null` also now fails startup with `IllegalStateException` instead of `IllegalArgumentException`, matching what the blocking stack already threw for the same mistake.
+This only happens in the Spring Boot integration. A `@Projection`, `@Saga` or `@Snapshot` bean's class-level advice, `@Transactional` or a custom aspect for example, no longer runs once at startup as a side effect of its descriptor factory being invoked. That was never documented behavior, just an accident of CGLIB proxying the bean under the default `spring.aop.proxy-target-class=true`.
+
+A reactor factory that returns `null` also now fails startup with `IllegalStateException` instead of `IllegalArgumentException`, matching what the blocking stack already threw for the same mistake.
 
 Full details are in the [changelog](https://github.com/johanhaleby/occurrent/blob/main/changelog.md), and the [upgrade guide](https://github.com/johanhaleby/occurrent/blob/main/doc/migration/upgrading-to-0.34.0.md) walks through every change with the by-hand translation where the recipe cannot reach.

--- a/_posts/news/2026-08-25-0_34_0.md
+++ b/_posts/news/2026-08-25-0_34_0.md
@@ -1,0 +1,28 @@
+---
+layout: news
+category: news
+date: 2026-08-25
+version: 0.34.0
+title: Version 0.34.0 Released
+summary: The flow saga's deprecated join is removed, a projection, subscription, query or snapshot declaring a supertype event is now refused, four MongoDB-only config keys move under mongodb, and a descriptor factory's class-level advice no longer runs at startup
+---
+
+Occurrent 0.34.0 is released. There is no new headline feature this time, so this post leads with the breaking changes worth reading before you upgrade.
+
+## The flow saga's `join` is removed
+
+The flow saga's deprecated `join`, Kotlin's `expect<T>`, and `Expectation` are gone. `join` was already deprecated in 0.33.0 in favor of `on(StepCondition, ...)` with `allOf(...)`, and that replacement is what every caller now needs. The new `UpgradeToOccurrent_0_34` OpenRewrite recipe rewrites a `join` call built from a literal list of literal `Expectation.of(...)` calls. A list built from a variable or a method call, and every Kotlin call site, are left alone and stop compiling, so the compiler finds them for you.
+
+## A supertype event declaration is now refused everywhere
+
+A projection, a subscription built through the subscription DSL, a query through `DomainEventQueries`, or a `@Snapshot` view that declares an event type whose concrete subtypes cannot be found is now refused, the same refusal 0.33.0 already shipped for a saga and an annotation-based subscription. Seal the hierarchy or declare the concrete event types to fix it, or set an explicit filter where one is available.
+
+## Four MongoDB-only config keys move under `mongodb`
+
+`occurrent.event-store.collection`, `occurrent.event-store.time-representation`, `occurrent.subscription.collection` and `occurrent.subscription.restart-on-change-stream-history-lost` are renamed to their `mongodb`-qualified equivalents. Each old key still works and is deprecated, removed in the release after next, and the new recipe rewrites both `.properties` and `.yaml` for you.
+
+## A descriptor factory's class-level advice no longer runs at startup
+
+A `@Projection`, `@Saga` or `@Snapshot` bean's class-level advice, `@Transactional` or a custom aspect for example, no longer runs once at startup as a side effect of its descriptor factory being invoked. That was never a documented behavior, an accident of CGLIB proxying the bean under the default `spring.aop.proxy-target-class=true`. A reactor factory that returns `null` also now fails startup with `IllegalStateException` instead of `IllegalArgumentException`, matching what the blocking stack already threw for the same mistake.
+
+Full details are in the [changelog](https://github.com/johanhaleby/occurrent/blob/main/changelog.md), and the [upgrade guide](https://github.com/johanhaleby/occurrent/blob/main/doc/migration/upgrading-to-0.34.0.md) walks through every change with the by-hand translation where the recipe cannot reach.

--- a/_posts/news/2026-08-25-0_34_0.md
+++ b/_posts/news/2026-08-25-0_34_0.md
@@ -17,7 +17,7 @@ Declaring a sealed event supertype now matches every concrete type it permits, i
 
 ### PushSubscriptionModel gets an observation hook
 
-`PushSubscriptionModel` takes an optional `PushObserver` that tells you whether each delivered event matched a registered subscription, so a misconfigured queue binding or a type-mapping typo is now visible instead of silent.
+`PushSubscriptionModel` takes an optional `PushObserver` that reports each pushed event's `RoutingOutcome` (`DELIVERED`, `FILTERED` or `NOT_DELIVERABLE`), so a misconfigured queue binding or a type-mapping typo is now visible instead of silent.
 
 ### The deprecated `join` is gone, with a recipe for the mechanical part
 


### PR DESCRIPTION
Hold, merges at the 0.34.0 release. Do not merge before then.

Based on `main` at `eb1f2fe4205412a53394ab2f780a79a9fda62545`.

## What I changed

- I bumped `occurrentversion` to `0.34.0` in `_config.yml`.
- I added `_posts/news/2026-08-25-0_34_0.md`, the 0.34.0 release announcement. It summarizes the library changelog's Breaking changes for this release. The Highlights section is still empty there, so the post leads with what breaks instead of a headline feature.

The date in the filename and front matter, `2026-08-25`, is a placeholder. I'll set the real release date at release, the same release-day item PR 54's post needed fixed before it could merge.
